### PR TITLE
Adaptation supports intermediate types

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ dotnet add package AlephMapper
 Using `PackageReference`:
 
 ```xml
-<PackageReference Include="AlephMapper" Version="0.5.6">
+<PackageReference Include="AlephMapper" Version="0.5.7">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 </PackageReference>
@@ -51,7 +51,7 @@ With Central Package Management:
 
 ```xml
 <!-- Directory.Packages.props -->
-<PackageVersion Include="AlephMapper" Version="0.5.6" />
+<PackageVersion Include="AlephMapper" Version="0.5.7" />
 
 <!-- Project file -->
 <PackageReference Include="AlephMapper">

--- a/source/Adaptation/AdaptationValidator.cs
+++ b/source/Adaptation/AdaptationValidator.cs
@@ -16,7 +16,11 @@ namespace AlephMapper.Adaptation;
 /// </summary>
 internal static class AdaptationValidator
 {
-    public static bool Validate(SourceProductionContext context, MappingModel mapping, AdaptationModel adaptation)
+    public static bool Validate(
+        SourceProductionContext context,
+        MappingModel mapping,
+        AdaptationModel adaptation,
+        ExpressionSyntax inlinedBody)
     {
         var location = adaptation.Attribute.ApplicationSyntaxReference?.GetSyntax().GetLocation()
             ?? mapping.MethodSymbol.Locations.FirstOrDefault();
@@ -41,7 +45,8 @@ internal static class AdaptationValidator
             mapping.BodySyntax.Expression,
             mapping.SemanticModel,
             mapping.ReturnType).ToArray();
-        if (destinationCreations.Length == 0)
+        var hasInlinedDestinationCreation = inlinedBody.GetAnnotatedNodes(SyntaxRewriters.InliningResolver.InlinedReturnCreationAnnotation).Any();
+        if (destinationCreations.Length == 0 && !hasInlinedDestinationCreation)
         {
             context.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.AdaptUnsupportedSyntax,

--- a/source/Adaptation/AdaptedDestinationRewriter.cs
+++ b/source/Adaptation/AdaptedDestinationRewriter.cs
@@ -4,6 +4,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using AlephMapper.SyntaxRewriters;
+using AlephMapper.Helpers;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -16,19 +18,33 @@ namespace AlephMapper.Adaptation;
 internal sealed class AdaptedDestinationRewriter : CSharpSyntaxRewriter
 {
     private readonly HashSet<TextSpan> _destinationCreationSpans;
+    private readonly HashSet<TextSpan> _inlinedDestinationCreationSpans;
     private readonly HashSet<string> _destinationCreationTypeTexts;
     private readonly TypeSyntax _adaptedDestinationType;
+    private readonly ITypeSymbol _adaptedDestinationTypeSymbol;
+    private readonly NullableContext _nullableContext;
+    private readonly HashSet<string> _originalDestinationTypeTexts;
     private readonly ExpressionSyntax _root;
+    private readonly Stack<ITypeSymbol> _objectInitializerTypeStack = new();
+    private readonly Stack<ITypeSymbol> _expectedExpressionTypeStack = new();
 
     private AdaptedDestinationRewriter(
         IEnumerable<TextSpan> destinationCreationSpans,
+        IEnumerable<TextSpan> inlinedDestinationCreationSpans,
         IEnumerable<string> destinationCreationTypeTexts,
+        IEnumerable<string> originalDestinationTypeTexts,
         string adaptedDestinationTypeName,
+        ITypeSymbol adaptedDestinationTypeSymbol,
+        NullableContext nullableContext,
         ExpressionSyntax root)
     {
         _destinationCreationSpans = new HashSet<TextSpan>(destinationCreationSpans);
+        _inlinedDestinationCreationSpans = new HashSet<TextSpan>(inlinedDestinationCreationSpans);
         _destinationCreationTypeTexts = new HashSet<string>(destinationCreationTypeTexts);
         _adaptedDestinationType = SyntaxFactory.ParseTypeName(adaptedDestinationTypeName);
+        _adaptedDestinationTypeSymbol = adaptedDestinationTypeSymbol;
+        _nullableContext = nullableContext;
+        _originalDestinationTypeTexts = new HashSet<string>(originalDestinationTypeTexts);
         _root = root;
     }
 
@@ -37,7 +53,9 @@ internal sealed class AdaptedDestinationRewriter : CSharpSyntaxRewriter
         ExpressionSyntax bodyToRewrite,
         SemanticModel semanticModel,
         ITypeSymbol originalDestinationType,
-        string adaptedDestinationTypeName)
+        string adaptedDestinationTypeName,
+        ITypeSymbol adaptedDestinationType,
+        NullableContext nullableContext)
     {
         if (bodyToRewrite is ImplicitObjectCreationExpressionSyntax implicitCreation)
         {
@@ -62,28 +80,228 @@ internal sealed class AdaptedDestinationRewriter : CSharpSyntaxRewriter
             .ToArray();
 
         var spans = destinationCreations.Select(node => node.Span);
+        var inlinedSpans = bodyToRewrite
+            .GetAnnotatedNodes(InliningResolver.InlinedReturnCreationAnnotation)
+            .OfType<ExpressionSyntax>()
+            .Select(node => node.Span);
         var typeTexts = destinationCreations
             .OfType<ObjectCreationExpressionSyntax>()
             .Select(node => node.Type.ToString());
+        var originalDestinationTypeTexts = GetTypeTextCandidates(originalDestinationType);
 
-        return (ExpressionSyntax)new AdaptedDestinationRewriter(spans, typeTexts, adaptedDestinationTypeName, bodyToRewrite)
+        return (ExpressionSyntax)new AdaptedDestinationRewriter(
+                spans,
+                inlinedSpans,
+                typeTexts,
+                originalDestinationTypeTexts,
+                adaptedDestinationTypeName,
+                adaptedDestinationType,
+                nullableContext,
+                bodyToRewrite)
             .Visit(bodyToRewrite)!;
     }
 
     public override SyntaxNode VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
     {
-        var rewritten = (ObjectCreationExpressionSyntax)base.VisitObjectCreationExpression(node)!;
-        return _destinationCreationSpans.Contains(node.Span) || _destinationCreationTypeTexts.Contains(node.Type.ToString())
-            ? rewritten.WithType(_adaptedDestinationType.WithTriviaFrom(rewritten.Type))
-            : rewritten;
+        var targetType = GetObjectCreationTargetType(node);
+        var typeSyntax = targetType == null
+            ? null
+            : SyntaxFactory.ParseTypeName(GetObjectCreationTypeName(targetType)).WithTriviaFrom(node.Type);
+
+        if (targetType != null)
+        {
+            _objectInitializerTypeStack.Push(targetType);
+        }
+
+        try
+        {
+            var argumentList = node.ArgumentList == null ? null : (ArgumentListSyntax?)Visit(node.ArgumentList);
+            var initializer = node.Initializer == null ? null : (InitializerExpressionSyntax?)Visit(node.Initializer);
+            return node
+                .WithArgumentList(argumentList)
+                .WithInitializer(initializer)
+                .WithType(typeSyntax ?? node.Type);
+        }
+        finally
+        {
+            if (targetType != null)
+            {
+                _objectInitializerTypeStack.Pop();
+            }
+        }
+    }
+
+    public override SyntaxNode VisitCastExpression(CastExpressionSyntax node)
+    {
+        var rewritten = (CastExpressionSyntax)base.VisitCastExpression(node)!;
+        var targetType = GetExpectedExpressionType();
+        return targetType != null && IsAdaptableObjectType(targetType) && !_originalDestinationTypeTexts.Contains(node.Type.ToString())
+            ? rewritten.WithType(SyntaxFactory.ParseTypeName(GetCastTypeName(targetType)).WithTriviaFrom(rewritten.Type))
+            : _originalDestinationTypeTexts.Contains(node.Type.ToString())
+                ? rewritten.WithType(SyntaxFactory.ParseTypeName(GetCastTypeName(_adaptedDestinationTypeSymbol)).WithTriviaFrom(rewritten.Type))
+                : rewritten;
+    }
+
+    public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
+    {
+        var left = (ExpressionSyntax)Visit(node.Left)!;
+        var expectedType = TryGetAssignedMemberType(node.Left);
+        if (expectedType != null)
+        {
+            _expectedExpressionTypeStack.Push(expectedType);
+        }
+
+        try
+        {
+            var right = (ExpressionSyntax)Visit(node.Right)!;
+            return node.WithLeft(left).WithRight(right);
+        }
+        finally
+        {
+            if (expectedType != null)
+            {
+                _expectedExpressionTypeStack.Pop();
+            }
+        }
+    }
+
+    public override SyntaxNode VisitConditionalExpression(ConditionalExpressionSyntax node)
+    {
+        var condition = (ExpressionSyntax)Visit(node.Condition)!;
+        var expectedType = GetExpectedExpressionType();
+        if (expectedType != null)
+        {
+            _expectedExpressionTypeStack.Push(expectedType);
+        }
+
+        try
+        {
+            return node
+                .WithCondition(condition)
+                .WithWhenTrue((ExpressionSyntax)Visit(node.WhenTrue)!)
+                .WithWhenFalse((ExpressionSyntax)Visit(node.WhenFalse)!);
+        }
+        finally
+        {
+            if (expectedType != null)
+            {
+                _expectedExpressionTypeStack.Pop();
+            }
+        }
     }
 
     public override SyntaxNode VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
     {
         var rewritten = (ImplicitObjectCreationExpressionSyntax)base.VisitImplicitObjectCreationExpression(node)!;
-        return _destinationCreationSpans.Contains(node.Span) || ReferenceEquals(node, _root)
-            ? SyntaxFactory.ObjectCreationExpression(_adaptedDestinationType, rewritten.ArgumentList ?? SyntaxFactory.ArgumentList(), rewritten.Initializer)
+        var targetType = _destinationCreationSpans.Contains(node.Span) || ReferenceEquals(node, _root)
+            ? _adaptedDestinationTypeSymbol
+            : GetExpectedExpressionType();
+
+        return targetType != null && IsAdaptableObjectType(targetType)
+            ? SyntaxFactory.ObjectCreationExpression(
+                    SyntaxFactory.ParseTypeName(GetObjectCreationTypeName(targetType)),
+                    rewritten.ArgumentList ?? SyntaxFactory.ArgumentList(),
+                    rewritten.Initializer)
                 .WithTriviaFrom(rewritten)
             : rewritten;
+    }
+
+    private ITypeSymbol? GetObjectCreationTargetType(ObjectCreationExpressionSyntax node)
+    {
+        if (_destinationCreationSpans.Contains(node.Span) ||
+            _inlinedDestinationCreationSpans.Contains(node.Span) ||
+            _destinationCreationTypeTexts.Contains(node.Type.ToString()))
+        {
+            return _adaptedDestinationTypeSymbol;
+        }
+
+        var expectedType = GetExpectedExpressionType();
+        return expectedType != null && IsAdaptableObjectType(expectedType) ? expectedType : null;
+    }
+
+    private ITypeSymbol? GetExpectedExpressionType()
+    {
+        return _expectedExpressionTypeStack.Count == 0 ? null : _expectedExpressionTypeStack.Peek();
+    }
+
+    private ITypeSymbol? TryGetAssignedMemberType(ExpressionSyntax left)
+    {
+        if (_objectInitializerTypeStack.Count == 0)
+        {
+            return null;
+        }
+
+        var memberName = left switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.Text,
+            _ => null
+        };
+
+        if (memberName == null)
+        {
+            return null;
+        }
+
+        var currentType = _objectInitializerTypeStack.Peek();
+        var member = GetMembersIncludingBaseTypes(currentType, memberName)
+            .FirstOrDefault(symbol => symbol is IPropertySymbol or IFieldSymbol);
+        return member switch
+        {
+            IPropertySymbol property => property.Type,
+            IFieldSymbol field => field.Type,
+            _ => null
+        };
+    }
+
+    private static IEnumerable<ISymbol> GetMembersIncludingBaseTypes(ITypeSymbol type, string name)
+    {
+        for (var current = type as INamedTypeSymbol; current != null; current = current.BaseType)
+        {
+            foreach (var member in current.GetMembers(name))
+            {
+                yield return member;
+            }
+        }
+    }
+
+    private string GetObjectCreationTypeName(ITypeSymbol type)
+    {
+        return TypeDisplay.ForSymbol(type, NullableAnnotation.NotAnnotated, _nullableContext);
+    }
+
+    private string GetCastTypeName(ITypeSymbol type)
+    {
+        var annotation = type.NullableAnnotation == NullableAnnotation.Annotated
+            ? NullableAnnotation.Annotated
+            : NullableAnnotation.NotAnnotated;
+        return TypeDisplay.ForSymbol(type, annotation, _nullableContext);
+    }
+
+    private static bool IsAdaptableObjectType(ITypeSymbol type)
+    {
+        return type.TypeKind == TypeKind.Class &&
+               !type.IsAbstract &&
+               type is INamedTypeSymbol { IsGenericType: false };
+    }
+
+    private static HashSet<string> GetTypeTextCandidates(ITypeSymbol type)
+    {
+        var candidates = new HashSet<string>(System.StringComparer.Ordinal)
+        {
+            type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+            type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", string.Empty)
+        };
+
+        if (type is INamedTypeSymbol { TypeArguments.Length: 0 } namedType)
+        {
+            candidates.Add(namedType.Name);
+            candidates.Add(namedType.Name + "?");
+        }
+
+        candidates.Add(type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat) + "?");
+        candidates.Add(type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", string.Empty) + "?");
+
+        return candidates;
     }
 }

--- a/source/AlephMapper.csproj
+++ b/source/AlephMapper.csproj
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Raffinert/AlephMapper</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageVersion>0.5.6</PackageVersion>
+    <PackageVersion>0.5.7</PackageVersion>
     <PackageTags>Mapping Companion</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Raffinert/AlephMapper.git</RepositoryUrl>

--- a/source/Generation/Emitters/AdaptationMemberEmitter.cs
+++ b/source/Generation/Emitters/AdaptationMemberEmitter.cs
@@ -65,7 +65,7 @@ internal static class AdaptationMemberEmitter
                 continue;
             }
 
-            if (!AdaptationValidator.Validate(context.SourceProductionContext, mapping, adaptation))
+            if (!AdaptationValidator.Validate(context.SourceProductionContext, mapping, adaptation, inlinedBody))
             {
                 continue;
             }
@@ -75,7 +75,9 @@ internal static class AdaptationMemberEmitter
                 inlinedBody,
                 mapping.SemanticModel,
                 mapping.ReturnType,
-                destinationTypeName);
+                destinationTypeName,
+                adaptation.DestinationType,
+                details.NullableContext);
             var adaptedBodyText = PrettyPrinter.Print(adaptedBody, 2);
 
             var adaptationParameterTypes = new[] { sourceTypeName }.Concat(details.ParameterTypeNames.Skip(1)).ToArray();
@@ -153,7 +155,9 @@ internal static class AdaptationMemberEmitter
                     inlinedUpdateBody,
                     mapping.SemanticModel,
                     mapping.ReturnType,
-                    destinationTypeName);
+                    destinationTypeName,
+                    adaptation.DestinationType,
+                    details.NullableContext);
                 var lines = new List<string>();
                 if (!EmitHelpers.TryBuildUpdateAssignmentsWithInlining(
                         adaptedUpdateBody,

--- a/source/SyntaxRewriters/InliningResolver.ImplicitObjectCreationRewriter.cs
+++ b/source/SyntaxRewriters/InliningResolver.ImplicitObjectCreationRewriter.cs
@@ -7,6 +7,14 @@ namespace AlephMapper.SyntaxRewriters;
 
 internal sealed partial class InliningResolver
 {
+    public override SyntaxNode VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
+    {
+        var rewritten = base.VisitObjectCreationExpression(node)!;
+        return IsAnnotatedReturnCreation(node)
+            ? rewritten.WithAdditionalAnnotations(new SyntaxAnnotation(InlinedReturnCreationAnnotation))
+            : rewritten;
+    }
+
     public override SyntaxNode VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax implicitNew)
     {
         var type = model.GetTypeInfo(implicitNew).Type?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
@@ -28,6 +36,17 @@ internal sealed partial class InliningResolver
             objectCreation = objectCreation.WithArgumentList((ArgumentListSyntax)VisitArgumentList(implicitNew.ArgumentList));
         }
 
-        return objectCreation.WithNewKeyword(Token(SyntaxKind.NewKeyword).WithTrailingTrivia(Space));
+        objectCreation = objectCreation.WithNewKeyword(Token(SyntaxKind.NewKeyword).WithTrailingTrivia(Space));
+        return IsAnnotatedReturnCreation(implicitNew)
+            ? objectCreation.WithAdditionalAnnotations(new SyntaxAnnotation(InlinedReturnCreationAnnotation))
+            : objectCreation;
+    }
+
+    private bool IsAnnotatedReturnCreation(ExpressionSyntax expression)
+    {
+        return returnTypeToAnnotate != null &&
+               SymbolEqualityComparer.Default.Equals(
+                   model.GetTypeInfo(expression).Type ?? model.GetTypeInfo(expression).ConvertedType,
+                   returnTypeToAnnotate);
     }
 }

--- a/source/SyntaxRewriters/InliningResolver.InvocationRewriter.cs
+++ b/source/SyntaxRewriters/InliningResolver.InvocationRewriter.cs
@@ -14,9 +14,13 @@ internal sealed partial class InliningResolver(
     SemanticModel model,
     IDictionary<IMethodSymbol, MappingModel> catalog,
     bool forUpdateMethod,
-    NullConditionalRewrite rewriteSupport)
+    NullConditionalRewrite rewriteSupport,
+    ITypeSymbol returnTypeToAnnotate = null)
     : CSharpSyntaxRewriter
 {
+    internal const string InlinedConditionalAnnotation = "AlephMapper.InlinedConditional";
+    internal const string InlinedReturnCreationAnnotation = "AlephMapper.InlinedReturnCreation";
+
     private HashSet<IMethodSymbol> _callStack = new(SymbolEqualityComparer.Default);
     private List<CircularReferenceInfo> _circularReferences = [];
     private Dictionary<IMethodSymbol, MappingModel> _inlinedMethods = new(SymbolEqualityComparer.Default);
@@ -93,7 +97,7 @@ internal sealed partial class InliningResolver(
                         {
                             _inlinedMethods[normalizedMethod] = callee;
                             var inlinedBody =
-                                (ExpressionSyntax)new InliningResolver(callee.SemanticModel, catalog, forUpdateMethod, rewriteSupport)
+                                (ExpressionSyntax)new InliningResolver(callee.SemanticModel, catalog, forUpdateMethod, rewriteSupport, callee.ReturnType)
                                 {
                                     _callStack = _callStack,
                                     _circularReferences = _circularReferences,
@@ -159,7 +163,7 @@ internal sealed partial class InliningResolver(
         try
         {
             _inlinedMethods[directCallMethod] = callee2;
-            var inlinedBody2 = (ExpressionSyntax)new InliningResolver(callee2.SemanticModel, catalog, forUpdateMethod, rewriteSupport)
+            var inlinedBody2 = (ExpressionSyntax)new InliningResolver(callee2.SemanticModel, catalog, forUpdateMethod, rewriteSupport, callee2.ReturnType)
             {
                 _callStack = _callStack,
                 _circularReferences = _circularReferences,
@@ -172,7 +176,7 @@ internal sealed partial class InliningResolver(
 
             if (conditionalAccessExpression)
             {
-                substituted = substituted.WithAdditionalAnnotations(new SyntaxAnnotation("AlephMapper.InlinedConditional"));
+                substituted = substituted.WithAdditionalAnnotations(new SyntaxAnnotation(InlinedConditionalAnnotation));
             }
 
             return substituted;
@@ -282,4 +286,3 @@ internal class CircularReferenceInfo(IMethodSymbol method, IEnumerable<IMethodSy
     public IMethodSymbol Method { get; } = method;
     public string CallChain { get; } = string.Join(" -> ", callStack.Select(m => $"{m.ContainingType.Name}.{m.Name}"));
 }
-

--- a/source/SyntaxRewriters/InliningResolver.NullConditionalRewriter.cs
+++ b/source/SyntaxRewriters/InliningResolver.NullConditionalRewriter.cs
@@ -24,7 +24,7 @@ internal partial class InliningResolver
             {
                 _conditionalAccessExpressionsStack.Push(node.Expression);
                 var rewritten = (ExpressionSyntax)base.VisitConditionalAccessExpression(node)!;
-                var annotated = rewritten.GetAnnotatedNodes("AlephMapper.InlinedConditional").ToArray();
+                var annotated = rewritten.GetAnnotatedNodes(InlinedConditionalAnnotation).ToArray();
                 if (annotated.FirstOrDefault() is { } ann) return ann;
                 return rewritten;
             }

--- a/source/VersionInfo.cs
+++ b/source/VersionInfo.cs
@@ -2,5 +2,5 @@
 
 internal static class VersionInfo
 {
-    public static string Version => "0.5.6";
+    public static string Version => "0.5.7";
 }

--- a/tests/AlephMapper.IntegrationTests/MultiParamMappers.cs
+++ b/tests/AlephMapper.IntegrationTests/MultiParamMappers.cs
@@ -1,4 +1,4 @@
-namespace AlephMapper.IntegrationTests;
+﻿namespace AlephMapper.IntegrationTests;
 
 // ──────────────────────────────────────────────────────────────────
 // 1. Expressive mapper with multi-parameter helper inlining
@@ -7,8 +7,8 @@ namespace AlephMapper.IntegrationTests;
 public static partial class MultiParamEmployeeMapper
 {
     // Two-parameter helper: concatenate first + last
-    public static string FormatName(string first, string last) =>
-        first + " " + last;
+    public static string FormatName(string first, string last, string separator) =>
+        first + separator + last;
 
     // Three-parameter helper: build a formatted address string
     public static string FormatAddress(string street, string city, string country) =>
@@ -20,7 +20,7 @@ public static partial class MultiParamEmployeeMapper
 
     // Nested multi-param: calls FormatName internally
     public static string FormatNameWithEmail(string first, string last, string email) =>
-        FormatName(first, last) + " <" + email + ">";
+        FormatName(first, last, " ") + " <" + email + ">";
 
     // Single-param helper to ensure mixing single + multi works
     public static string GetDepartmentName(Employee employee) =>
@@ -28,13 +28,13 @@ public static partial class MultiParamEmployeeMapper
 
     // ── Expression mapping that uses all the above helpers ──
     [Expressive]
-    public static EmployeeDto MapToDto(Employee employee) => new()
+    public static EmployeeDto MapToDto(Employee e) => new()
     {
-        Id = employee.Id,
-        FullName = FormatName(employee.FirstName, employee.LastName),
-        Email = employee.Email,
-        DepartmentName = GetDepartmentName(employee),
-        IsActive = employee.IsActive
+        Id = e.Id,
+        FullName = FormatName(e.FirstName, e.LastName, " "),
+        Email = e.Email,
+        DepartmentName = GetDepartmentName(e),
+        IsActive = e.IsActive
     };
 
     // Mapping that exercises three-parameter helper

--- a/tests/AlephMapper.IntegrationTests/MultiParamTests.cs
+++ b/tests/AlephMapper.IntegrationTests/MultiParamTests.cs
@@ -1,4 +1,4 @@
-using AgileObjects.ReadableExpressions;
+﻿using AgileObjects.ReadableExpressions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
@@ -39,9 +39,11 @@ public class MultiParamIntegrationTests
         var expression = MultiParamEmployeeMapper.MapToDtoExpression();
 
         // Act
-        var dtos = await _context.Employees
+        var query = _context.Employees
             .Select(expression)
-            .ToListAsync();
+            .Where(e => e.IsActive);
+
+        var dtos = await query.ToListAsync();
 
         // Assert
         await Assert.That(dtos.Count).IsEqualTo(6);

--- a/tests/AlephMapper.Tests/Files/AdaptBoth/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptBoth/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/AdaptNested/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptNested/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/AdaptUpdate/Expected/Tests_AdaptUpdateMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptUpdate/Expected/Tests_AdaptUpdateMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class AdaptUpdateMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CircularMapper/Expected/AlephMapper_Tests_CircularMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CircularMapper/Expected/AlephMapper_Tests_CircularMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class CircularMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CircularPropertyMapper/Expected/AlephMapper_Tests_CircularPropertyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CircularPropertyMapper/Expected/AlephMapper_Tests_CircularPropertyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class CircularPropertyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CollectionMapper/Expected/AlephMapper_Tests_CollectionMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CollectionMapper/Expected/AlephMapper_Tests_CollectionMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class CollectionMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ConditionalPatternMapper/Expected/AlephMapper_Tests_ConditionalPatternMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ConditionalPatternMapper/Expected/AlephMapper_Tests_ConditionalPatternMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class ConditionalPatternMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreIgnoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreIgnoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class EfCoreIgnoreMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class EfCoreMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/Expressive/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Expressive/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class SampleMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ConditionalExtensionTestPersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ConditionalExtensionTestPersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class ConditionalExtensionTestPersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestAddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestAddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class ExtensionTestAddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestPersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestPersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class ExtensionTestPersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/Mapper/Expected/AlephMapper_Tests_Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Mapper/Expected/AlephMapper_Tests_Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MethodGroupSpec/Expected/AlephMapper_Tests_SimpleObjectMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MethodGroupSpec/Expected/AlephMapper_Tests_SimpleObjectMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class SimpleObjectMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MethodGroupToEntityList/Expected/AlephMapper_Tests_MethodGroupToEntityList_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MethodGroupToEntityList/Expected/AlephMapper_Tests_MethodGroupToEntityList_PersonMapper_GeneratedMappings.g.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MethodGroupToEntityList;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperIgnore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperIgnore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class PersonProductMapperIgnore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperRewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperRewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class PersonProductMapperRewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_ProductMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_ProductMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class ProductMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_MultiParamExpressiveMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_MultiParamExpressiveMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class MultiParamExpressiveMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NamedArgMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NamedArgMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class NamedArgMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NestedMultiParamMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NestedMultiParamMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class NestedMultiParamMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_UpdatableMultiParamMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_UpdatableMultiParamMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class UpdatableMultiParamMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_AddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_AddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class NestedExt_AddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Ignore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Ignore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class NestedExt_PersonMapper_Ignore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Rewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Rewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class NestedExt_PersonMapper_Rewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullCoalesceValueAssignment/Expected/AlephMapper_Tests_NullCoalesceValueAssignmentMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullCoalesceValueAssignment/Expected/AlephMapper_Tests_NullCoalesceValueAssignmentMapper_GeneratedMappings.g.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class NullCoalesceValueAssignmentMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_IgnoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_IgnoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class IgnoreMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_NoneMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_NoneMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class NoneMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_RewriteMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_RewriteMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class RewriteMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullableDisabled/Expected/Tests_NullableDisabledMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullableDisabled/Expected/Tests_NullableDisabledMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class NullableDisabledMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullableEnabled/Expected/Tests_NullableEnabledMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullableEnabled/Expected/Tests_NullableEnabledMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class NullableEnabledMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtAddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtAddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class TechDebtAddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperIgnore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperIgnore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class TechDebtPersonMapperIgnore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperNone_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperNone_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class TechDebtPersonMapperNone
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperRewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperRewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class TechDebtPersonMapperRewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_Address1Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_Address1Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class Address1Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_AddressLineMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_AddressLineMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class AddressLineMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_TestModel1Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_TestModel1Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class TestModel1Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/Updatable/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Updatable/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class SampleMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexPropertyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexPropertyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class ComplexPropertyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class ComplexValueTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_EdgeCaseMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_EdgeCaseMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class EdgeCaseMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_MixedTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_MixedTypeMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using TUnit.Core;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class MixedTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_NullableValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_NullableValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class NullableValueTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ReferenceTypeOnlyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ReferenceTypeOnlyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class ReferenceTypeOnlyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_SimpleValueToReferenceMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_SimpleValueToReferenceMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class SimpleValueToReferenceMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueToReferenceMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueToReferenceMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class ValueToReferenceMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class ValueTypeMapper
 {
 }

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeOnlyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeOnlyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.6")]
+[GeneratedCode("AlephMapper", "0.5.7")]
 partial class ValueTypeOnlyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/SourceGeneratorTests.cs
+++ b/tests/AlephMapper.Tests/SourceGeneratorTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -28,7 +28,7 @@ public class SourceGeneratorTests
 
         foreach (var testCaseGroup in groupedByTestCase)
         {
-            var testCaseName = Path.GetFileName(testCaseGroup.Key)!;
+            var testCaseName = Path.GetFileName(testCaseGroup.Key);
             var sourceFiles = testCaseGroup
                 .Where(n => n.GetNoneFilePath().Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).SkipWhile(x => x != "Files").Take(3).Last() == "Sources")
                 .Select(n => n.GetNoneFilePath())
@@ -89,7 +89,7 @@ public class SourceGeneratorTests
         var result = driver.GetRunResult().Results.Single();
 
         var actualSources = result.GeneratedSources.ToDictionary(
-            source => Path.GetFileName(source.HintName)!,
+            source => Path.GetFileName(source.HintName),
             source => NormalizeLineEndings(source.SourceText.ToString()),
             StringComparer.Ordinal);
 
@@ -242,6 +242,225 @@ public class SourceGeneratorTests
     }
 
     [Test]
+    public async Task AdaptedOutputSupportsNullConditionalRewrite()
+    {
+        const string source = """
+            #nullable enable
+            using AlephMapper;
+
+            namespace Fixture;
+
+            public static partial class Mapper
+            {
+                [Adapt(typeof(Employee), typeof(EmployeeDto), Name = "MapEmployee", NullConditionalRewrite = NullConditionalRewrite.Rewrite)]
+                public static PersonDto MapPerson(Person source) => new() { Street = source.Address?.Street ?? "Unknown" };
+            }
+
+            public sealed class Person { public Address? Address { get; set; } }
+            public sealed class Employee { public Address? Address { get; set; } }
+            public sealed class Address { public string Street { get; set; } = string.Empty; }
+            public sealed class PersonDto { public string Street { get; set; } = string.Empty; }
+            public sealed class EmployeeDto { public string Street { get; set; } = string.Empty; }
+            """;
+
+        var generatedSources = await AssertAdaptedOutputCompiles(source, "NullConditionalAdapt");
+        var generatedSource = generatedSources.Single(sourceText => sourceText.Contains("MapEmployeeExpression"));
+
+        await Assert.That(generatedSource).DoesNotContain("?.");
+        await Assert.That(generatedSource).Contains("source.Address != null");
+    }
+
+    [Test]
+    public async Task AdaptedOutputSupportsNullConditionalRewriteWithExtensionInlining()
+    {
+        const string source = """
+            #nullable enable
+            using AlephMapper;
+
+            namespace Fixture;
+
+            public static partial class AddressMapper
+            {
+                public static AddressDto ToDto(this Address source) => new() { Street = source.Street };
+            }
+
+            public static partial class Mapper
+            {
+                [Adapt(typeof(Employee), typeof(EmployeeDto), Name = "MapEmployee", NullConditionalRewrite = NullConditionalRewrite.Rewrite)]
+                public static PersonDto MapPerson(Person source) => new() { Address = source.Address?.ToDto() };
+            }
+
+            public sealed class Person { public Address? Address { get; set; } }
+            public sealed class Employee { public Address? Address { get; set; } }
+            public sealed class Address { public string Street { get; set; } = string.Empty; }
+            public sealed class PersonDto { public AddressDto? Address { get; set; } }
+            public sealed class EmployeeDto { public AddressDto? Address { get; set; } }
+            public sealed class AddressDto { public string Street { get; set; } = string.Empty; }
+            """;
+
+        var generatedSources = await AssertAdaptedOutputCompiles(source, "NullConditionalExtensionAdapt");
+        var generatedSource = generatedSources.Single(sourceText => sourceText.Contains("MapEmployeeExpression"));
+
+        await Assert.That(generatedSource).DoesNotContain("?.");
+        await Assert.That(generatedSource).DoesNotContain(".ToDto(");
+        await Assert.That(generatedSource).Contains("source.Address != null");
+        await Assert.That(generatedSource).Contains("Street = source.Address.Street");
+    }
+
+    [Test]
+    public async Task AdaptedOutputSupportsNullConditionalRootExtensionInlining()
+    {
+        const string source = """
+            #nullable enable
+            using AlephMapper;
+
+            namespace Fixture;
+
+            public static partial class Mapper
+            {
+                [Adapt(typeof(Employee), typeof(EmployeeDto), Name = "MapEmployee", Generate = AdaptGeneration.Expression, NullConditionalRewrite = NullConditionalRewrite.Rewrite)]
+                public static PersonDto MapPerson(Person source) => source?.MapNonNullPerson();
+
+                private static PersonDto MapNonNullPerson(this Person source) => new()
+                {
+                    Name = source.Name,
+                    Tax = new TaxInfo { Rate = source.TaxRate }
+                };
+            }
+
+            public sealed class Person { public string Name { get; set; } = string.Empty; public decimal TaxRate { get; set; } }
+            public sealed class Employee { public string Name { get; set; } = string.Empty; public decimal TaxRate { get; set; } }
+            public sealed class PersonDto { public string Name { get; set; } = string.Empty; public TaxInfo Tax { get; set; } = new(); }
+            public sealed class EmployeeDto { public string Name { get; set; } = string.Empty; public EmployeeTaxInfo Tax { get; set; } = new(); }
+            public sealed class TaxInfo { public decimal Rate { get; set; } }
+            public sealed class EmployeeTaxInfo { public decimal Rate { get; set; } }
+            """;
+
+        var generatedSources = await AssertAdaptedOutputCompiles(source, "NullConditionalRootExtensionAdapt");
+        var generatedSource = generatedSources.Single(sourceText => sourceText.Contains("MapEmployeeExpression"));
+
+        await Assert.That(generatedSource).DoesNotContain("?.");
+        await Assert.That(generatedSource).DoesNotContain("MapNonNullPerson");
+        await Assert.That(generatedSource).Contains("source != null");
+        await Assert.That(generatedSource).Contains("new EmployeeDto");
+        await Assert.That(generatedSource).Contains("Tax = new EmployeeTaxInfo");
+    }
+
+    [Test]
+    public async Task AdaptedOutputSupportsComplexNullConditionalRootExtensionInlining()
+    {
+        const string source = """
+            #nullable enable
+            using AlephMapper;
+
+            namespace Fixture;
+
+            public static partial class OrderItemMapper
+            {
+                [Adapt(typeof(OrderItemInput), typeof(ReadOnlyOrderItem), Generate = AdaptGeneration.Expression, Name = "MapInputToReadOnlyItem", NullConditionalRewrite = NullConditionalRewrite.Rewrite)]
+                public static OrderItem MapInputToItem(this OrderItemInput source) => source?.MapNonNullInputToItem();
+
+                private static OrderItem MapNonNullInputToItem(this OrderItemInput source) => new()
+                {
+                    ProductName = source.ProductName,
+                    CurrencyCode = source.CurrencyCode,
+                    UnitPrice = source.UnitPrice,
+                    Quantity = source.Quantity,
+                    Subtotal = source.Subtotal.Round(2),
+                    Sequence = source.Sequence,
+                    Sku = source.Sku,
+                    DiscountAmount = source.Discount,
+                    TaxPercentage = source.TaxRate,
+                    IsArchived = false,
+                    TotalAmount = (source.Subtotal * (1m + source.TaxRate / 100m)).Round(2),
+                    OrderNumber = source.OrderNumber,
+                    OrderLineNumber = source.OrderLineNumber,
+                    Tax = new TaxInfo
+                    {
+                        Rate = source.TaxRate,
+                        Amount = (source.Subtotal * source.TaxRate / 100m).Round(2)
+                    }
+                };
+
+                private static decimal Round(this decimal value, int decimals) => decimal.Round(value, decimals);
+            }
+
+            public sealed class OrderItemInput
+            {
+                public string ProductName { get; set; } = string.Empty;
+                public string CurrencyCode { get; set; } = string.Empty;
+                public decimal UnitPrice { get; set; }
+                public decimal Quantity { get; set; }
+                public decimal Subtotal { get; set; }
+                public int Sequence { get; set; }
+                public string Sku { get; set; } = string.Empty;
+                public decimal Discount { get; set; }
+                public decimal TaxRate { get; set; }
+                public string OrderNumber { get; set; } = string.Empty;
+                public string OrderLineNumber { get; set; } = string.Empty;
+            }
+
+            public sealed class OrderItem
+            {
+                public string ProductName { get; set; } = string.Empty;
+                public string CurrencyCode { get; set; } = string.Empty;
+                public decimal UnitPrice { get; set; }
+                public decimal Quantity { get; set; }
+                public decimal Subtotal { get; set; }
+                public int Sequence { get; set; }
+                public string Sku { get; set; } = string.Empty;
+                public decimal DiscountAmount { get; set; }
+                public decimal TaxPercentage { get; set; }
+                public bool IsArchived { get; set; }
+                public decimal TotalAmount { get; set; }
+                public string OrderNumber { get; set; } = string.Empty;
+                public string OrderLineNumber { get; set; } = string.Empty;
+                public TaxInfo Tax { get; set; } = new();
+            }
+
+            public sealed class ReadOnlyOrderItem
+            {
+                public string ProductName { get; set; } = string.Empty;
+                public string CurrencyCode { get; set; } = string.Empty;
+                public decimal UnitPrice { get; set; }
+                public decimal Quantity { get; set; }
+                public decimal Subtotal { get; set; }
+                public int Sequence { get; set; }
+                public string Sku { get; set; } = string.Empty;
+                public decimal DiscountAmount { get; set; }
+                public decimal TaxPercentage { get; set; }
+                public bool IsArchived { get; set; }
+                public decimal TotalAmount { get; set; }
+                public string OrderNumber { get; set; } = string.Empty;
+                public string OrderLineNumber { get; set; } = string.Empty;
+                public ReadOnlyTaxInfo Tax { get; set; } = new();
+            }
+
+            public sealed class TaxInfo
+            {
+                public decimal Rate { get; set; }
+                public decimal Amount { get; set; }
+            }
+
+            public sealed class ReadOnlyTaxInfo
+            {
+                public decimal Rate { get; set; }
+                public decimal Amount { get; set; }
+            }
+            """;
+
+        var generatedSources = await AssertAdaptedOutputCompiles(source, "ComplexNullConditionalRootExtensionAdapt");
+        var generatedSource = generatedSources.Single(sourceText => sourceText.Contains("MapInputToReadOnlyItemExpression"));
+
+        await Assert.That(generatedSource).DoesNotContain("?.");
+        await Assert.That(generatedSource).DoesNotContain("MapNonNullInputToItem");
+        await Assert.That(generatedSource).Contains("source != null");
+        await Assert.That(generatedSource).Contains("new ReadOnlyOrderItem");
+        await Assert.That(generatedSource).Contains("Tax = new ReadOnlyTaxInfo");
+        await Assert.That(generatedSource).Contains("TotalAmount = decimal.Round((source.Subtotal * (1m + source.TaxRate / 100m)), 2)");
+    }
+
+    [Test]
     public async Task AdaptReportsIncompatibleDirectMemberAssignment()
     {
         const string source = """
@@ -311,7 +530,7 @@ public class SourceGeneratorTests
         await Assert.That(diagnostics.Any(diagnostic => diagnostic.Id == diagnosticId)).IsTrue();
     }
 
-    private async Task AssertAdaptedOutputCompiles(string source, string assemblyName)
+    private async Task<IReadOnlyList<string>> AssertAdaptedOutputCompiles(string source, string assemblyName)
     {
         var references = await ReferenceAssemblies.Net.Net90.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
         var compilation = CSharpCompilation.Create(
@@ -324,6 +543,9 @@ public class SourceGeneratorTests
         await Assert.That(generatorDiagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)).IsEmpty();
         await Assert.That(driver.GetRunResult().Results.Single().Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)).IsEmpty();
         await Assert.That(outputCompilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)).IsEmpty();
+        return driver.GetRunResult().Results.Single().GeneratedSources
+            .Select(sourceText => sourceText.SourceText.ToString())
+            .ToArray();
     }
 
     private static string CreateAdaptationSource(


### PR DESCRIPTION
# PR: Support intermediate types in adaptations

## Summary

This change expands `[Adapt]` so a mapping template can adapt nested/intermediate object types, not only its root destination type. It also aligns null-conditional rewriting in adapted mappings with the existing Expressive mapping behavior.

## Changes

- Rewrites nested object creations, implicit `new()` expressions, and casts according to the expected adapted destination-member type.
- Tracks destination object creations introduced while helper methods are inlined, allowing adapted mappings rooted in inlined helpers to be generated correctly.
- Updates adaptation validation to accept destination construction supplied by an inlined helper.
- Preserves and applies `NullConditionalRewrite.Rewrite` for adapted mapping expressions, including extension-method and root-level helper inlining.
- Adds source-generator coverage for direct, extension, and complex root null-conditional adaptation scenarios.
- Refreshes generated mapping snapshots and updates the package version from `0.5.6` to `0.5.7`.

## Validation

- Added/updated source-generator test coverage for the new adaptation and null-conditional cases.
- Not run locally (documentation-only follow-up).
