### PR TITLE
fix: generate single-source mapping expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ dotnet add package AlephMapper
 Using `PackageReference`:
 
 ```xml
-<PackageReference Include="AlephMapper" Version="0.5.7">
+<PackageReference Include="AlephMapper" Version="0.5.8">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 </PackageReference>
@@ -51,7 +51,7 @@ With Central Package Management:
 
 ```xml
 <!-- Directory.Packages.props -->
-<PackageVersion Include="AlephMapper" Version="0.5.7" />
+<PackageVersion Include="AlephMapper" Version="0.5.8" />
 
 <!-- Project file -->
 <PackageReference Include="AlephMapper">

--- a/examples/SampleApp/Program.cs
+++ b/examples/SampleApp/Program.cs
@@ -188,11 +188,11 @@ Console.WriteLine($"   DepartmentTitle:    {summary.DepartmentTitle}");
 Console.WriteLine($"   TotalCompensation:  {summary.TotalCompensation:C}");
 
 // Use the generated expression (multi-param helpers are inlined into the expression tree)
-var empExpression = EmployeeMapper.ToSummaryExpression();
+var empExpression = EmployeeMapper.ToSummaryExpression(DateTime.Now.Year);
 Console.WriteLine("\n   Generated Expression (helpers inlined):");
 Console.WriteLine($"   {empExpression}");
 var compiled = empExpression.Compile();
-var fromExpression = compiled(employee, DateTime.Now.Year);
+var fromExpression = compiled(employee);
 Console.WriteLine("\n   From compiled expression:");
 Console.WriteLine($"   FullName:           {fromExpression.FullName}");
 Console.WriteLine($"   TotalCompensation:  {fromExpression.TotalCompensation:C}");
@@ -230,10 +230,10 @@ Console.WriteLine($"   RoutingKey:  {contractorBrief.RoutingKey}");
 Console.WriteLine($"   Score:       {contractorBrief.Score}");
 
 // The expression companion is also generated for the adapted source/destination pair.
-var contractorExpression = AdaptExampleMapper.MapContractorBriefExpression();
+var contractorExpression = AdaptExampleMapper.MapContractorBriefExpression(DateTime.Now.Year, "TENANT-A");
 Console.WriteLine("\n   Generated Adapt Expression:");
 Console.WriteLine($"   {contractorExpression}");
-var contractorFromExpression = contractorExpression.Compile()(contractor, DateTime.Now.Year, "TENANT-A");
+var contractorFromExpression = contractorExpression.Compile()(contractor);
 Console.WriteLine($"\n   From compiled adapt expression: {contractorFromExpression.DisplayName} ({contractorFromExpression.RoutingKey})");
 
 Console.WriteLine("\n=== Mapping Demonstration Complete ===");

--- a/source/Adaptation/AdaptationMemberPlanner.cs
+++ b/source/Adaptation/AdaptationMemberPlanner.cs
@@ -40,6 +40,7 @@ internal sealed class AdaptationMemberPlanner
     public bool TryReserve(
         string mapName,
         IEnumerable<string> mapParameterTypes,
+        IEnumerable<string> expressionParameterTypes,
         bool generateMap,
         bool generateExpression,
         bool generateUpdate,
@@ -67,7 +68,7 @@ internal sealed class AdaptationMemberPlanner
                 return false;
             }
 
-            requestedSignatures.Add(MethodSignature.Build(expressionName, []));
+            requestedSignatures.Add(MethodSignature.Build(expressionName, expressionParameterTypes));
         }
 
         if (generateUpdate)

--- a/source/Adaptation/AdaptedDestinationRewriter.cs
+++ b/source/Adaptation/AdaptedDestinationRewriter.cs
@@ -18,7 +18,6 @@ namespace AlephMapper.Adaptation;
 internal sealed class AdaptedDestinationRewriter : CSharpSyntaxRewriter
 {
     private readonly HashSet<TextSpan> _destinationCreationSpans;
-    private readonly HashSet<TextSpan> _inlinedDestinationCreationSpans;
     private readonly HashSet<string> _destinationCreationTypeTexts;
     private readonly TypeSyntax _adaptedDestinationType;
     private readonly ITypeSymbol _adaptedDestinationTypeSymbol;
@@ -30,7 +29,6 @@ internal sealed class AdaptedDestinationRewriter : CSharpSyntaxRewriter
 
     private AdaptedDestinationRewriter(
         IEnumerable<TextSpan> destinationCreationSpans,
-        IEnumerable<TextSpan> inlinedDestinationCreationSpans,
         IEnumerable<string> destinationCreationTypeTexts,
         IEnumerable<string> originalDestinationTypeTexts,
         string adaptedDestinationTypeName,
@@ -39,7 +37,6 @@ internal sealed class AdaptedDestinationRewriter : CSharpSyntaxRewriter
         ExpressionSyntax root)
     {
         _destinationCreationSpans = new HashSet<TextSpan>(destinationCreationSpans);
-        _inlinedDestinationCreationSpans = new HashSet<TextSpan>(inlinedDestinationCreationSpans);
         _destinationCreationTypeTexts = new HashSet<string>(destinationCreationTypeTexts);
         _adaptedDestinationType = SyntaxFactory.ParseTypeName(adaptedDestinationTypeName);
         _adaptedDestinationTypeSymbol = adaptedDestinationTypeSymbol;
@@ -80,10 +77,6 @@ internal sealed class AdaptedDestinationRewriter : CSharpSyntaxRewriter
             .ToArray();
 
         var spans = destinationCreations.Select(node => node.Span);
-        var inlinedSpans = bodyToRewrite
-            .GetAnnotatedNodes(InliningResolver.InlinedReturnCreationAnnotation)
-            .OfType<ExpressionSyntax>()
-            .Select(node => node.Span);
         var typeTexts = destinationCreations
             .OfType<ObjectCreationExpressionSyntax>()
             .Select(node => node.Type.ToString());
@@ -91,7 +84,6 @@ internal sealed class AdaptedDestinationRewriter : CSharpSyntaxRewriter
 
         return (ExpressionSyntax)new AdaptedDestinationRewriter(
                 spans,
-                inlinedSpans,
                 typeTexts,
                 originalDestinationTypeTexts,
                 adaptedDestinationTypeName,
@@ -209,8 +201,8 @@ internal sealed class AdaptedDestinationRewriter : CSharpSyntaxRewriter
     private ITypeSymbol? GetObjectCreationTargetType(ObjectCreationExpressionSyntax node)
     {
         if (_destinationCreationSpans.Contains(node.Span) ||
-            _inlinedDestinationCreationSpans.Contains(node.Span) ||
-            _destinationCreationTypeTexts.Contains(node.Type.ToString()))
+            _destinationCreationTypeTexts.Contains(node.Type.ToString()) ||
+            _originalDestinationTypeTexts.Contains(node.Type.ToString()))
         {
             return _adaptedDestinationTypeSymbol;
         }

--- a/source/AlephMapper.csproj
+++ b/source/AlephMapper.csproj
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Raffinert/AlephMapper</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageVersion>0.5.7</PackageVersion>
+    <PackageVersion>0.5.8</PackageVersion>
     <PackageTags>Mapping Companion</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Raffinert/AlephMapper.git</RepositoryUrl>

--- a/source/Generation/Emitters/AdaptationMemberEmitter.cs
+++ b/source/Generation/Emitters/AdaptationMemberEmitter.cs
@@ -85,13 +85,14 @@ internal static class AdaptationMemberEmitter
             var updateParameterTypes = adaptationParameterTypes.Append(destinationTypeName).ToArray();
             var updateSignature = MethodSignature.Build(adaptationName, updateParameterTypes);
             var expressionName = adaptationName + "Expression";
-            var expressionSignature = expressionName + "()";
+            var expressionSignature = MethodSignature.Build(expressionName, details.ExtraExpressionParameterTypeNames);
             var generatedConflict = (generateMap && context.GeneratedMemberSignatures.Contains(mapSignature)) ||
                                     (generateExpression && context.GeneratedMemberSignatures.Contains(expressionSignature)) ||
                                     (generateUpdate && context.GeneratedMemberSignatures.Contains(updateSignature));
             var plannerConflict = !context.AdaptationMembers.TryReserve(
                 adaptationName,
                 adaptationParameterTypes,
+                details.ExtraExpressionParameterTypeNames,
                 generateMap,
                 generateExpression,
                 generateUpdate,
@@ -122,7 +123,7 @@ internal static class AdaptationMemberEmitter
             if (generateExpression)
             {
                 context.GeneratedMemberSignatures.Add(expressionSignature);
-                var functionArguments = string.Join(", ", new[] { sourceTypeName }.Concat(details.ParameterTypeNames.Skip(1)).Append(destinationTypeName));
+                var functionArguments = string.Join(", ", new[] { sourceTypeName, destinationTypeName });
                 EmitExpressionMember(details, expressionName, functionArguments, adaptedBodyText, context);
             }
 
@@ -213,8 +214,11 @@ internal static class AdaptationMemberEmitter
             members.AppendLine("    /// <summary>");
             members.AppendLine($"    /// This is an auto-generated adapted expression companion for <see cref=\"{details.Mapping.Name}({details.MethodParameterList})\"/>.");
             members.AppendLine("    /// </summary>");
-            members.AppendLine("    public static Expression<Func<" + functionArguments + ">> " + expressionName + "() => ");
-            members.Append("        " + details.LambdaParameters + " => ");
+            var expressionMethodParameters = string.IsNullOrEmpty(details.ExtraExpressionParameterListWithNames)
+                ? "()"
+                : "(" + details.ExtraExpressionParameterListWithNames + ")";
+            members.AppendLine("    public static Expression<Func<" + functionArguments + ">> " + expressionName + expressionMethodParameters + " => ");
+            members.Append("        " + details.ProjectionLambdaParameter + " => ");
             members.AppendLine(adaptedBodyText + ";");
         });
     }

--- a/source/Generation/Emitters/ExpressiveMemberEmitter.cs
+++ b/source/Generation/Emitters/ExpressiveMemberEmitter.cs
@@ -29,7 +29,7 @@ internal static class ExpressiveMemberEmitter
         }
 
         var expressionMethodName = mapping.Name + "Expression";
-        context.GeneratedMemberSignatures.Add(expressionMethodName + "()");
+        context.GeneratedMemberSignatures.Add(MethodSignature.Build(expressionMethodName, details.ExtraExpressionParameterTypeNames));
         var nullStrategyDescription = mapping.NullStrategy switch
         {
             NullConditionalRewrite.None => "Null-conditional operators are preserved as-is in the expression tree.",
@@ -37,8 +37,11 @@ internal static class ExpressiveMemberEmitter
             NullConditionalRewrite.Rewrite => "Null-conditional operators are rewritten as explicit null checks for better compatibility.",
             _ => "Default null handling strategy is applied."
         };
-        var funcTypeArguments = string.Join(", ", details.ParameterTypeNames.Append(details.DestinationTypeName));
+        var funcTypeArguments = string.Join(", ", new[] { details.SourceTypeName, details.DestinationTypeName });
         var prettyBody = PrettyPrinter.Print(inlinedBody, 2);
+        var expressionMethodParameters = string.IsNullOrEmpty(details.ExtraExpressionParameterListWithNames)
+            ? "()"
+            : "(" + details.ExtraExpressionParameterListWithNames + ")";
 
         context.AppendMember(members =>
         {
@@ -50,8 +53,8 @@ internal static class ExpressiveMemberEmitter
             members.AppendLine($"    /// Null handling strategy: {nullStrategyDescription}");
             members.AppendLine("    /// </para>");
             members.AppendLine("    /// </remarks>");
-            members.AppendLine("    public static Expression<Func<" + funcTypeArguments + ">> " + expressionMethodName + "() => ");
-            members.Append("        " + details.LambdaParameters + " => ");
+            members.AppendLine("    public static Expression<Func<" + funcTypeArguments + ">> " + expressionMethodName + expressionMethodParameters + " => ");
+            members.Append("        " + details.ProjectionLambdaParameter + " => ");
             members.AppendLine(prettyBody + ";");
         });
     }

--- a/source/Generation/MappingMethodDetails.cs
+++ b/source/Generation/MappingMethodDetails.cs
@@ -24,9 +24,13 @@ internal sealed class MappingMethodDetails
         MethodParameterList = string.Join(", ", ParameterTypeNames);
         MethodParameterListWithNames = string.Join(", ", mapping.Parameters.Select(parameter =>
             $"{TypeDisplay.ForSymbol(parameter.Type, parameter.NullableAnnotation, nullableContext)} {parameter.Name}"));
+        ExtraExpressionParameterTypeNames = ParameterTypeNames.Skip(1).ToArray();
+        ExtraExpressionParameterListWithNames = string.Join(", ", mapping.Parameters.Skip(1).Select(parameter =>
+            $"{TypeDisplay.ForSymbol(parameter.Type, parameter.NullableAnnotation, nullableContext)} {parameter.Name}"));
         LambdaParameters = mapping.Parameters.Count == 1
             ? mapping.Parameters[0].Name
             : "(" + string.Join(", ", mapping.Parameters.Select(parameter => parameter.Name)) + ")";
+        ProjectionLambdaParameter = mapping.Parameters[0].Name;
         NullableContext = nullableContext;
     }
 
@@ -37,6 +41,9 @@ internal sealed class MappingMethodDetails
     public string SourceName { get; }
     public string MethodParameterList { get; }
     public string MethodParameterListWithNames { get; }
+    public string[] ExtraExpressionParameterTypeNames { get; }
+    public string ExtraExpressionParameterListWithNames { get; }
     public string LambdaParameters { get; }
+    public string ProjectionLambdaParameter { get; }
     public Microsoft.CodeAnalysis.NullableContext NullableContext { get; }
 }

--- a/source/VersionInfo.cs
+++ b/source/VersionInfo.cs
@@ -2,5 +2,5 @@
 
 internal static class VersionInfo
 {
-    public static string Version => "0.5.7";
+    public static string Version => "0.5.8";
 }

--- a/tests/AlephMapper.IntegrationTests/MultiParamMappers.cs
+++ b/tests/AlephMapper.IntegrationTests/MultiParamMappers.cs
@@ -113,7 +113,7 @@ public static partial class MultiParamUpdatableMapper
 
 // ──────────────────────────────────────────────────────────────────
 // 4. Multi-parameter [Expressive] method itself
-//    Generates Expression<Func<Employee, int, EmployeeDto>>
+//    Generates Expression<Func<Employee, EmployeeDto>> MapWithYearExpression(int currentYear)
 // ──────────────────────────────────────────────────────────────────
 [Expressive(NullConditionalRewrite = NullConditionalRewrite.Rewrite)]
 public static partial class MultiParamExpressiveMapper

--- a/tests/AlephMapper.IntegrationTests/MultiParamTests.cs
+++ b/tests/AlephMapper.IntegrationTests/MultiParamTests.cs
@@ -46,7 +46,7 @@ public class MultiParamIntegrationTests
         var dtos = await query.ToListAsync();
 
         // Assert
-        await Assert.That(dtos.Count).IsEqualTo(6);
+        await Assert.That(dtos.Count).IsEqualTo(5);
 
         var john = dtos.First(d => d.Id == 1);
         await Assert.That(john.FullName).IsEqualTo("John Doe");
@@ -231,28 +231,19 @@ public class MultiParamIntegrationTests
     [Test]
     public async Task MultiParam_Expressive_Method_Should_Generate_Correct_Expression()
     {
-        // Arrange — MapWithYear takes (Employee, int) → generates Expression<Func<Employee, int, EmployeeDto>>
-        var expression = MultiParamExpressiveMapper.MapWithYearExpression();
+        // Arrange — MapWithYear takes (Employee, int) and generates a single-parameter projection factory
+        var expression = MultiParamExpressiveMapper.MapWithYearExpression(2026);
 
-        // Act — compile and invoke (can't use directly with EF since it's a two-param expression)
-        var compiled = expression.Compile();
-
-        var employee = new Employee
-        {
-            Id = 1,
-            FirstName = "John",
-            LastName = "Doe",
-            Email = "john@test.com",
-            IsActive = true,
-            Department = new Department { Name = "Engineering" }
-        };
-
-        var result = compiled(employee, 2026);
+        // Act
+        var result = await _context.Employees
+            .Where(employee => employee.Id == 1)
+            .Select(expression)
+            .SingleAsync();
 
         // Assert
         await Assert.That(result.Id).IsEqualTo(1);
         await Assert.That(result.FullName).IsEqualTo("John Doe");
-        await Assert.That(result.Email).IsEqualTo("john@test.com");
+        await Assert.That(result.Email).IsEqualTo("john.doe@company.com");
         await Assert.That(result.DepartmentName).IsEqualTo("Engineering");
         await Assert.That(result.IsActive).IsTrue();
         await Assert.That(result.YearsOfExperience).IsEqualTo(6); // 2026 - 2020
@@ -262,14 +253,15 @@ public class MultiParamIntegrationTests
     public async Task MultiParam_Expressive_Method_Should_Have_Correct_Expression_Structure()
     {
         // Arrange
-        var expression = MultiParamExpressiveMapper.MapWithYearExpression();
+        var currentYear = 2026;
+        var expression = MultiParamExpressiveMapper.MapWithYearExpression(currentYear);
         var readable = expression.ToReadableString();
 
         // Assert — the expression should reference both parameters
         await Assert.That(readable).Contains("new EmployeeDto");
         await Assert.That(readable).Contains("FirstName");
         await Assert.That(readable).Contains("LastName");
-        // The expression should have two lambda parameters
+        await Assert.That(expression.Parameters.Count).IsEqualTo(1);
         await Assert.That(readable).Contains("currentYear");
     }
 

--- a/tests/AlephMapper.Tests/Files/AdaptBoth/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptBoth/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/AdaptNested/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptNested/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class PersonMapper
 {
     /// <summary>
@@ -30,8 +30,8 @@ partial class PersonMapper
     /// <summary>
     /// This is an auto-generated adapted expression companion for <see cref="MapPerson(Person, bool)"/>.
     /// </summary>
-    public static Expression<Func<Employee, bool, EmployeeDto>> MapEmployeeExpression() => 
-        (source, includeEmail) => includeEmail
+    public static Expression<Func<Employee, EmployeeDto>> MapEmployeeExpression(bool includeEmail) => 
+        source => includeEmail
             ? new EmployeeDto
             {
                 Id = source.Id,
@@ -44,4 +44,19 @@ partial class PersonMapper
                 Name = source.FirstName + " " + source.LastName,
                 Email = string.Empty
             };
+
+    /// <summary>
+    /// This is an auto-generated adapted expression companion for <see cref="MapPersonWithDetail(PersonWithDetail, string)"/>.
+    /// </summary>
+    public static Expression<Func<EmployeeWithDetail, EmployeeWithDetailDto>> MapEmployeeWithDetailExpression(string userLanguageCode) => 
+        source => new EmployeeWithDetailDto
+        {
+            Id = source.Id,
+            Details = source.Details.Select(detail => new DetailDto
+            {
+                Code = detail.Code,
+                Description = detail.Descriptions
+            .Where(description => description.LanguageCode == userLanguageCode)            .Select(description => description.Text)            .FirstOrDefault() ?? detail.Code
+            }).ToList()
+        };
 }

--- a/tests/AlephMapper.Tests/Files/AdaptNested/Sources/Source.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptNested/Sources/Source.cs
@@ -18,6 +18,22 @@ public static partial class PersonMapper
             Name = source.FirstName + " " + source.LastName,
             Email = string.Empty
         };
+
+    [Adapt(typeof(EmployeeWithDetail), typeof(EmployeeWithDetailDto), Name = "MapEmployeeWithDetail", Generate = AdaptGeneration.Expression)]
+    public static PersonWithDetailDto MapPersonWithDetail(PersonWithDetail source, string userLanguageCode) => new()
+    {
+        Id = source.Id,
+        Details = source.Details.Select(detail => MapDetail(detail, userLanguageCode)).ToList()
+    };
+
+    public static DetailDto MapDetail(Detail detail, string userLanguageCode) => new()
+    {
+        Code = detail.Code,
+        Description = detail.Descriptions
+            .Where(description => description.LanguageCode == userLanguageCode)
+            .Select(description => description.Text)
+            .FirstOrDefault() ?? detail.Code
+    };
 }
 
 public class Person
@@ -48,4 +64,46 @@ public class EmployeeDto
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;
+}
+
+public class PersonWithDetail
+{
+    public int Id { get; set; }
+    public List<Detail> Details { get; set; } = [];
+}
+
+public class PersonWithDetailDto
+{
+    public int Id { get; set; }
+    public List<DetailDto> Details { get; set; } = [];
+}
+
+public class EmployeeWithDetail
+{
+    public int Id { get; set; }
+    public List<Detail> Details { get; set; } = [];
+}
+
+public class EmployeeWithDetailDto
+{
+    public int Id { get; set; }
+    public List<DetailDto> Details { get; set; } = [];
+}
+
+public class Detail
+{
+    public string Code { get; set; } = string.Empty;
+    public List<DetailDescription> Descriptions { get; set; } = [];
+}
+
+public class DetailDescription
+{
+    public string LanguageCode { get; set; } = string.Empty;
+    public string Text { get; set; } = string.Empty;
+}
+
+public class DetailDto
+{
+    public string Code { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
 }

--- a/tests/AlephMapper.Tests/Files/AdaptUpdate/Expected/Tests_AdaptUpdateMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptUpdate/Expected/Tests_AdaptUpdateMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class AdaptUpdateMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CircularMapper/Expected/AlephMapper_Tests_CircularMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CircularMapper/Expected/AlephMapper_Tests_CircularMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class CircularMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CircularPropertyMapper/Expected/AlephMapper_Tests_CircularPropertyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CircularPropertyMapper/Expected/AlephMapper_Tests_CircularPropertyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class CircularPropertyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CollectionMapper/Expected/AlephMapper_Tests_CollectionMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CollectionMapper/Expected/AlephMapper_Tests_CollectionMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class CollectionMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ConditionalPatternMapper/Expected/AlephMapper_Tests_ConditionalPatternMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ConditionalPatternMapper/Expected/AlephMapper_Tests_ConditionalPatternMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class ConditionalPatternMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreIgnoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreIgnoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class EfCoreIgnoreMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class EfCoreMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/Expressive/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Expressive/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class SampleMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ConditionalExtensionTestPersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ConditionalExtensionTestPersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class ConditionalExtensionTestPersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestAddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestAddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class ExtensionTestAddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestPersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestPersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class ExtensionTestPersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/Mapper/Expected/AlephMapper_Tests_Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Mapper/Expected/AlephMapper_Tests_Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MethodGroupSpec/Expected/AlephMapper_Tests_SimpleObjectMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MethodGroupSpec/Expected/AlephMapper_Tests_SimpleObjectMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class SimpleObjectMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MethodGroupToEntityList/Expected/AlephMapper_Tests_MethodGroupToEntityList_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MethodGroupToEntityList/Expected/AlephMapper_Tests_MethodGroupToEntityList_PersonMapper_GeneratedMappings.g.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MethodGroupToEntityList;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperIgnore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperIgnore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class PersonProductMapperIgnore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperRewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperRewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class PersonProductMapperRewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_ProductMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_ProductMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class ProductMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_MultiParamExpressiveMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_MultiParamExpressiveMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class MultiParamExpressiveMapper
 {
     /// <summary>
@@ -17,8 +17,8 @@ partial class MultiParamExpressiveMapper
     /// Null handling strategy: Null-conditional operators are ignored and treated as regular member access.
     /// </para>
     /// </remarks>
-    public static Expression<Func<Person, int, PersonDto>> MapExpression() => 
-        (person, currentYear) => new PersonDto
+    public static Expression<Func<Person, PersonDto>> MapExpression(int currentYear) => 
+        person => new PersonDto
         {
             FullName = person.First + " " + person.Last,
             BirthYear = currentYear - person.Age

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NamedArgMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NamedArgMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class NamedArgMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NestedMultiParamMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NestedMultiParamMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class NestedMultiParamMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_UpdatableMultiParamMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_UpdatableMultiParamMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class UpdatableMultiParamMapper
 {
     /// <summary>
@@ -17,8 +17,8 @@ partial class UpdatableMultiParamMapper
     /// Null handling strategy: Null-conditional operators are ignored and treated as regular member access.
     /// </para>
     /// </remarks>
-    public static Expression<Func<Person, int, PersonDto>> ToDtoExpression() => 
-        (person, currentYear) => new PersonDto
+    public static Expression<Func<Person, PersonDto>> ToDtoExpression(int currentYear) => 
+        person => new PersonDto
         {
             FullName = person.First + " " + person.Last,
             BirthYear = currentYear - person.Age

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Sources/PersonMapper.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Sources/PersonMapper.cs
@@ -82,7 +82,7 @@ public static partial class NestedMultiParamMapper
 
 /// <summary>
 /// Tests that a multi-parameter [Expressive] mapping method itself
-/// generates the correct Expression with multiple Func type arguments.
+/// generates a single-parameter projection expression factory.
 /// </summary>
 public static partial class MultiParamExpressiveMapper
 {

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_AddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_AddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class NestedExt_AddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Ignore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Ignore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class NestedExt_PersonMapper_Ignore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Rewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Rewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class NestedExt_PersonMapper_Rewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullCoalesceValueAssignment/Expected/AlephMapper_Tests_NullCoalesceValueAssignmentMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullCoalesceValueAssignment/Expected/AlephMapper_Tests_NullCoalesceValueAssignmentMapper_GeneratedMappings.g.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class NullCoalesceValueAssignmentMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_IgnoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_IgnoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class IgnoreMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_NoneMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_NoneMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class NoneMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_RewriteMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_RewriteMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class RewriteMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullableDisabled/Expected/Tests_NullableDisabledMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullableDisabled/Expected/Tests_NullableDisabledMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class NullableDisabledMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullableEnabled/Expected/Tests_NullableEnabledMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullableEnabled/Expected/Tests_NullableEnabledMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class NullableEnabledMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtAddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtAddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class TechDebtAddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperIgnore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperIgnore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class TechDebtPersonMapperIgnore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperNone_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperNone_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class TechDebtPersonMapperNone
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperRewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperRewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class TechDebtPersonMapperRewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_Address1Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_Address1Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class Address1Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_AddressLineMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_AddressLineMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class AddressLineMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_TestModel1Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_TestModel1Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class TestModel1Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/Updatable/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Updatable/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class SampleMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexPropertyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexPropertyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class ComplexPropertyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class ComplexValueTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_EdgeCaseMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_EdgeCaseMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class EdgeCaseMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_MixedTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_MixedTypeMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using TUnit.Core;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class MixedTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_NullableValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_NullableValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class NullableValueTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ReferenceTypeOnlyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ReferenceTypeOnlyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class ReferenceTypeOnlyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_SimpleValueToReferenceMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_SimpleValueToReferenceMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class SimpleValueToReferenceMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueToReferenceMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueToReferenceMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class ValueToReferenceMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class ValueTypeMapper
 {
 }

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeOnlyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeOnlyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.7")]
+[GeneratedCode("AlephMapper", "0.5.8")]
 partial class ValueTypeOnlyMapper
 {
     /// <summary>


### PR DESCRIPTION
Updates generated mapping expressions so the expression itself accepts only the source object. Additional mapping values are supplied to the generated expression factory method instead.

This applies to both `[Expressive]` mappings and `[Adapt]` expression companions. The update also improves generated-member signature conflict detection for expression factory parameters and fixes adapted destination rewriting for inlined object creations.

## Changes

- Generate expression factories with the original mapping parameters after the source parameter.
- Generate single-source `Expression<Func<TSource, TDestination>>` expressions.
- Update adapted expression companions and their signature planning.
- Correct adapted destination type rewriting for inlined destination creations.
- Update sample usage, generated-source snapshots, README package references, and version metadata for `0.5.8`.

## Validation

- `dotnet test tests/AlephMapper.Tests/AlephMapper.Tests.csproj --no-restore`
- `dotnet build examples/SampleApp/SampleApp.csproj --no-restore`
