### PR TITLE
Fix intermediate adaptation type generation when adapted mappings contain nested lambda expressions, and improve formatting of generated fluent call chains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ dotnet add package AlephMapper
 Using `PackageReference`:
 
 ```xml
-<PackageReference Include="AlephMapper" Version="0.5.8">
+<PackageReference Include="AlephMapper" Version="0.5.9">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 </PackageReference>
@@ -51,7 +51,7 @@ With Central Package Management:
 
 ```xml
 <!-- Directory.Packages.props -->
-<PackageVersion Include="AlephMapper" Version="0.5.8" />
+<PackageVersion Include="AlephMapper" Version="0.5.9" />
 
 <!-- Project file -->
 <PackageReference Include="AlephMapper">

--- a/source/Adaptation/AdaptationMemberPlanner.cs
+++ b/source/Adaptation/AdaptationMemberPlanner.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using AlephMapper.Helpers;
 using AlephMapper.Generation;
@@ -18,7 +18,6 @@ internal sealed class AdaptationMemberPlanner
     private readonly HashSet<string> _existingMethodSignatures;
     private readonly HashSet<string> _existingNonMethodNames;
     private readonly HashSet<string> _generatedMethodSignatures = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _generatedNonMethodNames = new(StringComparer.Ordinal);
 
     public AdaptationMemberPlanner(INamedTypeSymbol mapperType)
     {
@@ -50,7 +49,7 @@ internal sealed class AdaptationMemberPlanner
         var requestedSignatures = new List<string>();
         if (generateMap)
         {
-            if (_existingNonMethodNames.Contains(mapName) || _generatedNonMethodNames.Contains(mapName))
+            if (_existingNonMethodNames.Contains(mapName))
             {
                 conflict = mapName;
                 return false;
@@ -62,7 +61,7 @@ internal sealed class AdaptationMemberPlanner
         if (generateExpression)
         {
             var expressionName = mapName + "Expression";
-            if (_existingNonMethodNames.Contains(expressionName) || _generatedNonMethodNames.Contains(expressionName))
+            if (_existingNonMethodNames.Contains(expressionName))
             {
                 conflict = expressionName;
                 return false;
@@ -73,7 +72,7 @@ internal sealed class AdaptationMemberPlanner
 
         if (generateUpdate)
         {
-            if (_existingNonMethodNames.Contains(mapName) || _generatedNonMethodNames.Contains(mapName))
+            if (_existingNonMethodNames.Contains(mapName))
             {
                 conflict = mapName;
                 return false;

--- a/source/Adaptation/AdaptationValidator.cs
+++ b/source/Adaptation/AdaptationValidator.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using AlephMapper.Diagnostics;
 using AlephMapper.Models;
@@ -189,13 +189,13 @@ internal static class AdaptationValidator
         }
     }
 
-    private static bool TryResolveReadablePath(INamedTypeSymbol rootType, IEnumerable<string> path, out ISymbol member)
+    private static bool TryResolveReadablePath(INamedTypeSymbol rootType, IEnumerable<string> path, out ISymbol? member)
     {
         ITypeSymbol currentType = rootType;
         member = null!;
         foreach (var segment in path)
         {
-            member = GetReadableInstanceMember(currentType, segment)!;
+            member = GetReadableInstanceMember(currentType, segment);
             if (member == null)
             {
                 return false;

--- a/source/Adaptation/AdaptedDestinationRewriter.cs
+++ b/source/Adaptation/AdaptedDestinationRewriter.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using AlephMapper.SyntaxRewriters;
 using AlephMapper.Helpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -182,6 +183,16 @@ internal sealed class AdaptedDestinationRewriter : CSharpSyntaxRewriter
         }
     }
 
+    public override SyntaxNode VisitSimpleLambdaExpression(SimpleLambdaExpressionSyntax node)
+    {
+        return VisitLambdaWithoutOuterExpectedType(node, base.VisitSimpleLambdaExpression);
+    }
+
+    public override SyntaxNode VisitParenthesizedLambdaExpression(ParenthesizedLambdaExpressionSyntax node)
+    {
+        return VisitLambdaWithoutOuterExpectedType(node, base.VisitParenthesizedLambdaExpression);
+    }
+
     public override SyntaxNode VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
     {
         var rewritten = (ImplicitObjectCreationExpressionSyntax)base.VisitImplicitObjectCreationExpression(node)!;
@@ -295,5 +306,29 @@ internal sealed class AdaptedDestinationRewriter : CSharpSyntaxRewriter
         candidates.Add(type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", string.Empty) + "?");
 
         return candidates;
+    }
+
+    private T VisitLambdaWithoutOuterExpectedType<T>(T node, Func<T, SyntaxNode?> visit)
+        where T : LambdaExpressionSyntax
+    {
+        if (_expectedExpressionTypeStack.Count == 0)
+        {
+            return (T)visit(node)!;
+        }
+
+        var expectedTypes = _expectedExpressionTypeStack.Reverse().ToArray();
+        _expectedExpressionTypeStack.Clear();
+
+        try
+        {
+            return (T)visit(node)!;
+        }
+        finally
+        {
+            foreach (var expectedType in expectedTypes)
+            {
+                _expectedExpressionTypeStack.Push(expectedType);
+            }
+        }
     }
 }

--- a/source/AlephMapper.csproj
+++ b/source/AlephMapper.csproj
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Raffinert/AlephMapper</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageVersion>0.5.8</PackageVersion>
+    <PackageVersion>0.5.9</PackageVersion>
     <PackageTags>Mapping Companion</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Raffinert/AlephMapper.git</RepositoryUrl>

--- a/source/PrettyPrinter.cs
+++ b/source/PrettyPrinter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -135,6 +136,28 @@ public sealed class PrettyPrinter : CSharpSyntaxVisitor
         Visit(node.Right.WithoutLeadingTrivia());
     }
 
+    public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        if (!TryCollectFluentChain(node, out var root, out var calls))
+        {
+            base.VisitInvocationExpression(node);
+            return;
+        }
+
+        Visit(root.WithoutTrailingTrivia());
+        Indent();
+
+        foreach (var (name, arguments) in calls)
+        {
+            WriteLine();
+            WriteRaw(".");
+            Visit(name.WithoutTrivia());
+            Visit(arguments.WithoutTrivia());
+        }
+
+        Unindent();
+    }
+
     // -------- the only special case: object creation --------
 
     public override void VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
@@ -172,5 +195,27 @@ public sealed class PrettyPrinter : CSharpSyntaxVisitor
         Unindent();
         WriteLine();
         WriteRaw("}");
+    }
+
+    private static bool TryCollectFluentChain(
+        InvocationExpressionSyntax node,
+        out ExpressionSyntax root,
+        out IReadOnlyList<(SimpleNameSyntax Name, ArgumentListSyntax Arguments)> calls)
+    {
+        var collectedCalls = new List<(SimpleNameSyntax Name, ArgumentListSyntax Arguments)>();
+        ExpressionSyntax current = node;
+
+        while (current is InvocationExpressionSyntax invocation &&
+               invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+               memberAccess.OperatorToken.IsKind(SyntaxKind.DotToken))
+        {
+            collectedCalls.Add((memberAccess.Name, invocation.ArgumentList));
+            current = memberAccess.Expression;
+        }
+
+        collectedCalls.Reverse();
+        root = current;
+        calls = collectedCalls;
+        return collectedCalls.Count > 1;
     }
 }

--- a/source/VersionInfo.cs
+++ b/source/VersionInfo.cs
@@ -2,5 +2,5 @@
 
 internal static class VersionInfo
 {
-    public static string Version => "0.5.8";
+    public static string Version => "0.5.9";
 }

--- a/tests/AlephMapper.Tests/Files/AdaptBoth/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptBoth/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/AdaptNested/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptNested/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class PersonMapper
 {
     /// <summary>
@@ -52,11 +52,15 @@ partial class PersonMapper
         source => new EmployeeWithDetailDto
         {
             Id = source.Id,
-            Details = source.Details.Select(detail => new DetailDto
-            {
-                Code = detail.Code,
-                Description = detail.Descriptions
-            .Where(description => description.LanguageCode == userLanguageCode)            .Select(description => description.Text)            .FirstOrDefault() ?? detail.Code
-            }).ToList()
+            Details = source.Details
+                .Select(detail => new DetailDto
+                {
+                    Code = detail.Code,
+                    Description = detail.Descriptions
+                        .Where(description => description.LanguageCode == userLanguageCode)
+                        .Select(description => description.Text)
+                        .FirstOrDefault() ?? detail.Code
+                })
+                .ToList()
         };
 }

--- a/tests/AlephMapper.Tests/Files/AdaptUpdate/Expected/Tests_AdaptUpdateMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptUpdate/Expected/Tests_AdaptUpdateMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class AdaptUpdateMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CircularMapper/Expected/AlephMapper_Tests_CircularMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CircularMapper/Expected/AlephMapper_Tests_CircularMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class CircularMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CircularPropertyMapper/Expected/AlephMapper_Tests_CircularPropertyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CircularPropertyMapper/Expected/AlephMapper_Tests_CircularPropertyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class CircularPropertyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CollectionMapper/Expected/AlephMapper_Tests_CollectionMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CollectionMapper/Expected/AlephMapper_Tests_CollectionMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class CollectionMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ConditionalPatternMapper/Expected/AlephMapper_Tests_ConditionalPatternMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ConditionalPatternMapper/Expected/AlephMapper_Tests_ConditionalPatternMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class ConditionalPatternMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreIgnoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreIgnoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class EfCoreIgnoreMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class EfCoreMapper
 {
     /// <summary>
@@ -227,7 +227,9 @@ partial class EfCoreMapper
     /// </para>
     /// </remarks>
     public static Expression<Func<Person, decimal>> GetTotalOrderAmountExpression() => 
-        person => person.Orders.Where(o => o.IsCompleted).Sum(o => o.Amount);
+        person => person.Orders
+            .Where(o => o.IsCompleted)
+            .Sum(o => o.Amount);
 
     /// <summary>
     /// This is an auto-generated expression companion for <see cref="GetLatestOrderNumber(Person)"/>.
@@ -238,8 +240,12 @@ partial class EfCoreMapper
     /// </para>
     /// </remarks>
     public static Expression<Func<Person, string>> GetLatestOrderNumberExpression() => 
-        person => (person.Orders.OrderByDescending(o => o.OrderDate).FirstOrDefault() != null
-            ? (person.Orders.OrderByDescending(o => o.OrderDate).FirstOrDefault().OrderNumber) 
+        person => (person.Orders
+            .OrderByDescending(o => o.OrderDate)
+            .FirstOrDefault() != null
+            ? (person.Orders
+                .OrderByDescending(o => o.OrderDate)
+                .FirstOrDefault().OrderNumber) 
             : (string)null) ?? "No orders";
 
     /// <summary>
@@ -294,5 +300,7 @@ partial class EfCoreMapper
     /// </para>
     /// </remarks>
     public static Expression<Func<Person, bool>> IsVipCustomerExpression() => 
-        person => person.Orders.Where(o => o.IsCompleted).Sum(o => o.Amount) >= 1000m;
+        person => person.Orders
+            .Where(o => o.IsCompleted)
+            .Sum(o => o.Amount) >= 1000m;
 }

--- a/tests/AlephMapper.Tests/Files/Expressive/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Expressive/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class SampleMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ConditionalExtensionTestPersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ConditionalExtensionTestPersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class ConditionalExtensionTestPersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestAddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestAddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class ExtensionTestAddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestPersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestPersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class ExtensionTestPersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/Mapper/Expected/AlephMapper_Tests_Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Mapper/Expected/AlephMapper_Tests_Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MethodGroupSpec/Expected/AlephMapper_Tests_SimpleObjectMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MethodGroupSpec/Expected/AlephMapper_Tests_SimpleObjectMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class SimpleObjectMapper
 {
     /// <summary>
@@ -20,6 +20,8 @@ partial class SimpleObjectMapper
     public static Expression<Func<SimpleObject, SimpleDto>> MapToDtoExpression() => 
         so => new SimpleDto
         {
-            Attributes = so.Attributes.Select(attr => attr.Name).ToList() ?? new List<string>()
+            Attributes = so.Attributes
+                .Select(attr => attr.Name)
+                .ToList() ?? new List<string>()
         };
 }

--- a/tests/AlephMapper.Tests/Files/MethodGroupToEntityList/Expected/AlephMapper_Tests_MethodGroupToEntityList_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MethodGroupToEntityList/Expected/AlephMapper_Tests_MethodGroupToEntityList_PersonMapper_GeneratedMappings.g.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MethodGroupToEntityList;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class PersonMapper
 {
     /// <summary>
@@ -21,9 +21,11 @@ partial class PersonMapper
     public static Expression<Func<PersonDto, Person>> ToEntityExpression() => 
         dto => new Person
         {
-            ContactNumbers = dto.PhoneNumbers.Select(dto => new PhoneNumber
-            {
-                Number = dto.Number
-            }).ToList()
+            ContactNumbers = dto.PhoneNumbers
+                .Select(dto => new PhoneNumber
+                {
+                    Number = dto.Number
+                })
+                .ToList()
         };
 }

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperIgnore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperIgnore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class PersonProductMapperIgnore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperRewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperRewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class PersonProductMapperRewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_ProductMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_ProductMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class ProductMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_MultiParamExpressiveMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_MultiParamExpressiveMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class MultiParamExpressiveMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NamedArgMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NamedArgMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class NamedArgMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NestedMultiParamMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NestedMultiParamMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class NestedMultiParamMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_UpdatableMultiParamMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_UpdatableMultiParamMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class UpdatableMultiParamMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_AddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_AddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class NestedExt_AddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Ignore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Ignore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class NestedExt_PersonMapper_Ignore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Rewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Rewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class NestedExt_PersonMapper_Rewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullCoalesceValueAssignment/Expected/AlephMapper_Tests_NullCoalesceValueAssignmentMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullCoalesceValueAssignment/Expected/AlephMapper_Tests_NullCoalesceValueAssignmentMapper_GeneratedMappings.g.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class NullCoalesceValueAssignmentMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_IgnoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_IgnoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class IgnoreMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_NoneMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_NoneMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class NoneMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_RewriteMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_RewriteMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class RewriteMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullableDisabled/Expected/Tests_NullableDisabledMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullableDisabled/Expected/Tests_NullableDisabledMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class NullableDisabledMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullableEnabled/Expected/Tests_NullableEnabledMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullableEnabled/Expected/Tests_NullableEnabledMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class NullableEnabledMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtAddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtAddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class TechDebtAddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperIgnore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperIgnore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class TechDebtPersonMapperIgnore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperNone_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperNone_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class TechDebtPersonMapperNone
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperRewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperRewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class TechDebtPersonMapperRewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_Address1Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_Address1Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class Address1Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_AddressLineMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_AddressLineMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class AddressLineMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_TestModel1Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_TestModel1Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class TestModel1Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/Updatable/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Updatable/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class SampleMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexPropertyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexPropertyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class ComplexPropertyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class ComplexValueTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_EdgeCaseMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_EdgeCaseMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class EdgeCaseMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_MixedTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_MixedTypeMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using TUnit.Core;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class MixedTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_NullableValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_NullableValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class NullableValueTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ReferenceTypeOnlyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ReferenceTypeOnlyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class ReferenceTypeOnlyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_SimpleValueToReferenceMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_SimpleValueToReferenceMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class SimpleValueToReferenceMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueToReferenceMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueToReferenceMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class ValueToReferenceMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class ValueTypeMapper
 {
 }

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeOnlyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeOnlyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.8")]
+[GeneratedCode("AlephMapper", "0.5.9")]
 partial class ValueTypeOnlyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/SourceGeneratorTests.cs
+++ b/tests/AlephMapper.Tests/SourceGeneratorTests.cs
@@ -461,6 +461,61 @@ public class SourceGeneratorTests
     }
 
     [Test]
+    public async Task AdaptedOutputDoesNotApplyOuterAssignmentTypeInsideLambdas()
+    {
+        const string source = """
+            using AlephMapper;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            namespace Fixture;
+
+            public static partial class Mapper
+            {
+                [Adapt(typeof(Employee), typeof(EmployeeDto), Name = "MapEmployee", Generate = AdaptGeneration.Expression)]
+                public static PersonDto MapPerson(Person source, string preferredLanguage, string fallbackLanguage) => new()
+                {
+                    Description = MapDescription(source.Value, preferredLanguage, fallbackLanguage)
+                };
+
+                private static string MapDescription(Value value, string preferredLanguage, string fallbackLanguage) =>
+                    value.Descriptions
+                        .Select(description => description.ToDescriptionWithOrder(preferredLanguage, fallbackLanguage))
+                        .Where(description => description.Order < 3)
+                        .OrderBy(description => description.Order)
+                        .Select(description => description.Description)
+                        .FirstOrDefault() ?? value.Code;
+
+                private static DescriptionWithOrder ToDescriptionWithOrder(this Description description, string preferredLanguage, string fallbackLanguage) =>
+                    new()
+                    {
+                        Order = description.Language == preferredLanguage ? 1 : description.Language == fallbackLanguage ? 2 : 3,
+                        Description = description.Text
+                    };
+
+                private sealed class DescriptionWithOrder
+                {
+                    public int Order { get; set; }
+                    public string Description { get; set; } = string.Empty;
+                }
+            }
+
+            public sealed class Person { public Value Value { get; set; } = new(); }
+            public sealed class Employee { public Value Value { get; set; } = new(); }
+            public sealed class PersonDto { public string Description { get; set; } = string.Empty; }
+            public sealed class EmployeeDto { public string Description { get; set; } = string.Empty; }
+            public sealed class Value { public string Code { get; set; } = string.Empty; public List<Description> Descriptions { get; set; } = []; }
+            public sealed class Description { public string Language { get; set; } = string.Empty; public string Text { get; set; } = string.Empty; }
+            """;
+
+        var generatedSources = await AssertAdaptedOutputCompiles(source, "LambdaOuterAssignmentTypeAdapt");
+        var generatedSource = generatedSources.Single(sourceText => sourceText.Contains("MapEmployeeExpression"));
+
+        await Assert.That(generatedSource).DoesNotContain("new string");
+        await Assert.That(generatedSource).Contains("new DescriptionWithOrder");
+    }
+
+    [Test]
     public async Task AdaptReportsIncompatibleDirectMemberAssignment()
     {
         const string source = """


### PR DESCRIPTION
# PR Summary

## Summary

Fix intermediate adaptation type generation when adapted mappings contain nested lambda expressions, and improve formatting of generated fluent call chains.

## Changes

- Clears the outer expected-expression type while rewriting simple and parenthesized lambdas, then restores it afterward. This prevents an enclosing assignment type from being incorrectly applied to object creations inside lambda bodies.
- Updates the pretty printer to render multi-call fluent invocation chains across indented lines for clearer generated source.
- Adjusts adaptation member-planning checks so only existing non-method members block generated member names.
- Tightens nullable handling in adaptation path validation.
- Adds a regression test covering adapted output with LINQ lambdas and nested object creation.
- Updates generated-source snapshots and package/documentation version references from `0.5.8` to `0.5.9`.

## Testing

Passed:

- `dotnet test tests/AlephMapper.Tests/AlephMapper.Tests.csproj --no-restore` — 36 passed, 0 failed, 0 skipped.
- `dotnet test tests/AlephMapper.IntegrationTests/AlephMapper.IntegrationTests.csproj --no-restore` — 35 passed, 0 failed, 0 skipped.

The test run completed with existing package, nullable-reference, analyzer, and generated-attribute conflict warnings.
