### PR TITLE
PrettyPrinter: Improve readability of anonymous object initializers inside fluent LINQ chains and chained logical conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ dotnet add package AlephMapper
 Using `PackageReference`:
 
 ```xml
-<PackageReference Include="AlephMapper" Version="0.5.9">
+<PackageReference Include="AlephMapper" Version="0.6.0">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 </PackageReference>
@@ -51,7 +51,7 @@ With Central Package Management:
 
 ```xml
 <!-- Directory.Packages.props -->
-<PackageVersion Include="AlephMapper" Version="0.5.9" />
+<PackageVersion Include="AlephMapper" Version="0.6.0" />
 
 <!-- Project file -->
 <PackageReference Include="AlephMapper">

--- a/source/AlephMapper.csproj
+++ b/source/AlephMapper.csproj
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Raffinert/AlephMapper</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageVersion>0.5.9</PackageVersion>
+    <PackageVersion>0.6.0</PackageVersion>
     <PackageTags>Mapping Companion</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Raffinert/AlephMapper.git</RepositoryUrl>

--- a/source/PrettyPrinter.cs
+++ b/source/PrettyPrinter.cs
@@ -39,6 +39,8 @@ public sealed class PrettyPrinter : CSharpSyntaxVisitor
 
     private void WriteLine()
     {
+        TrimTrailingWhitespace(0, includeLineBreaks: false);
+
         // Avoid stacking multiple blank lines when we're already at the start of a line
         if (_sb.Length > 0)
         {
@@ -54,7 +56,7 @@ public sealed class PrettyPrinter : CSharpSyntaxVisitor
         _atLineStart = true;
     }
 
-    private void TrimTrailingWhitespace(int startIndex)
+    private void TrimTrailingWhitespace(int startIndex, bool includeLineBreaks = true)
     {
         var length = _sb.Length;
 
@@ -62,7 +64,7 @@ public sealed class PrettyPrinter : CSharpSyntaxVisitor
         {
             var ch = _sb[length - 1];
 
-            if (ch == '\r' || ch == '\n' || ch == ' ' || ch == '\t')
+            if (ch == ' ' || ch == '\t' || (includeLineBreaks && (ch == '\r' || ch == '\n')))
             {
                 length--;
                 continue;
@@ -129,6 +131,23 @@ public sealed class PrettyPrinter : CSharpSyntaxVisitor
 
     public override void VisitBinaryExpression(BinaryExpressionSyntax node)
     {
+        if (TryCollectLogicalChain(node, out var operands, out var operatorText))
+        {
+            Visit(operands[0].WithoutTrailingTrivia());
+            Indent();
+
+            for (var i = 1; i < operands.Count; i++)
+            {
+                WriteLine();
+                WriteRaw(operatorText);
+                WriteRaw(" ");
+                Visit(operands[i].WithoutLeadingTrivia());
+            }
+
+            Unindent();
+            return;
+        }
+
         Visit(node.Left.WithoutTrailingTrivia());
         WriteRaw(" ");
         WriteRaw(node.OperatorToken.Text);
@@ -197,6 +216,42 @@ public sealed class PrettyPrinter : CSharpSyntaxVisitor
         WriteRaw("}");
     }
 
+    public override void VisitAnonymousObjectCreationExpression(AnonymousObjectCreationExpressionSyntax node)
+    {
+        WriteRaw("new");
+        WriteLine();
+        WriteRaw("{");
+        Indent();
+
+        var initializers = node.Initializers;
+        for (int i = 0; i < initializers.Count; i++)
+        {
+            WriteLine();
+            WriteRaw(string.Empty);
+            var entryStart = _sb.Length;
+            VisitAnonymousObjectMemberDeclarator(initializers[i]);
+            TrimTrailingWhitespace(entryStart);
+
+            if (i < initializers.Count - 1)
+                _sb.Append(",");
+        }
+
+        Unindent();
+        WriteLine();
+        WriteRaw("}");
+    }
+
+    public override void VisitAnonymousObjectMemberDeclarator(AnonymousObjectMemberDeclaratorSyntax node)
+    {
+        if (node.NameEquals != null)
+        {
+            Visit(node.NameEquals.Name.WithoutTrivia());
+            WriteRaw(" = ");
+        }
+
+        Visit(node.Expression.WithoutLeadingTrivia());
+    }
+
     private static bool TryCollectFluentChain(
         InvocationExpressionSyntax node,
         out ExpressionSyntax root,
@@ -217,5 +272,63 @@ public sealed class PrettyPrinter : CSharpSyntaxVisitor
         root = current;
         calls = collectedCalls;
         return collectedCalls.Count > 1;
+    }
+
+    private static bool TryCollectLogicalChain(
+        BinaryExpressionSyntax node,
+        out IReadOnlyList<ExpressionSyntax> operands,
+        out string operatorText)
+    {
+        operands = [];
+        operatorText = node.OperatorToken.Text;
+        if (!IsLogicalChainOperator(node.Kind()) || !HasLineBreakInLogicalChain(node, node.Kind()))
+        {
+            return false;
+        }
+
+        var collectedOperands = new List<ExpressionSyntax>();
+        CollectLogicalOperands(node, node.Kind(), collectedOperands);
+        operands = collectedOperands;
+        return collectedOperands.Count > 1;
+    }
+
+    private static void CollectLogicalOperands(
+        ExpressionSyntax expression,
+        SyntaxKind chainKind,
+        List<ExpressionSyntax> operands)
+    {
+        if (expression is BinaryExpressionSyntax binaryExpression && binaryExpression.IsKind(chainKind))
+        {
+            CollectLogicalOperands(binaryExpression.Left, chainKind, operands);
+            CollectLogicalOperands(binaryExpression.Right, chainKind, operands);
+            return;
+        }
+
+        operands.Add(expression);
+    }
+
+    private static bool IsLogicalChainOperator(SyntaxKind kind)
+    {
+        return kind is SyntaxKind.LogicalAndExpression or SyntaxKind.LogicalOrExpression;
+    }
+
+    private static bool HasLineBreakInLogicalChain(ExpressionSyntax expression, SyntaxKind chainKind)
+    {
+        if (expression is not BinaryExpressionSyntax binaryExpression || !binaryExpression.IsKind(chainKind))
+        {
+            return false;
+        }
+
+        return ContainsLineBreak(binaryExpression.Left.GetTrailingTrivia()) ||
+               ContainsLineBreak(binaryExpression.OperatorToken.LeadingTrivia) ||
+               ContainsLineBreak(binaryExpression.OperatorToken.TrailingTrivia) ||
+               ContainsLineBreak(binaryExpression.Right.GetLeadingTrivia()) ||
+               HasLineBreakInLogicalChain(binaryExpression.Left, chainKind) ||
+               HasLineBreakInLogicalChain(binaryExpression.Right, chainKind);
+    }
+
+    private static bool ContainsLineBreak(SyntaxTriviaList trivia)
+    {
+        return trivia.Any(triviaItem => triviaItem.IsKind(SyntaxKind.EndOfLineTrivia));
     }
 }

--- a/source/VersionInfo.cs
+++ b/source/VersionInfo.cs
@@ -2,5 +2,5 @@
 
 internal static class VersionInfo
 {
-    public static string Version => "0.5.9";
+    public static string Version => "0.6.0";
 }

--- a/tests/AlephMapper.Tests/Files/AdaptBoth/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptBoth/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/AdaptNested/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptNested/Expected/Tests_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/AdaptUpdate/Expected/Tests_AdaptUpdateMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/AdaptUpdate/Expected/Tests_AdaptUpdateMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class AdaptUpdateMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CircularMapper/Expected/AlephMapper_Tests_CircularMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CircularMapper/Expected/AlephMapper_Tests_CircularMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class CircularMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CircularPropertyMapper/Expected/AlephMapper_Tests_CircularPropertyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CircularPropertyMapper/Expected/AlephMapper_Tests_CircularPropertyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class CircularPropertyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/CollectionMapper/Expected/AlephMapper_Tests_CollectionMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/CollectionMapper/Expected/AlephMapper_Tests_CollectionMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class CollectionMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ConditionalPatternMapper/Expected/AlephMapper_Tests_ConditionalPatternMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ConditionalPatternMapper/Expected/AlephMapper_Tests_ConditionalPatternMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class ConditionalPatternMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreIgnoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreIgnoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class EfCoreIgnoreMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class EfCoreMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/EfCoreMapper/Expected/AlephMapper_Tests_EfCoreMapper_GeneratedMappings.g.cs
@@ -23,17 +23,17 @@ partial class EfCoreMapper
             Name = p.Name,
             Email = p.Email,
             Age = (p.BirthInfo != null
-                ? (p.BirthInfo.Age) 
+                ? (p.BirthInfo.Age)
                 : (int?)null),
             BirthPlace = (p.BirthInfo != null
-                ? (p.BirthInfo.BirthPlace) 
+                ? (p.BirthInfo.BirthPlace)
                 : (string)null) ?? "Unknown",
             BirthAddress = (p.BirthInfo != null
-                ? (p.BirthInfo.Address) 
+                ? (p.BirthInfo.Address)
                 : (string)null) ?? "Not specified",
             HasBirthInfo = p.BirthInfo != null,
             IsAdult = (p.BirthInfo != null
-                ? (p.BirthInfo.Age) 
+                ? (p.BirthInfo.Age)
                 : (int?)null) >= 18,
             AddressCount = p.Addresses.Count,
             OrderCount = p.Orders.Count,
@@ -46,7 +46,7 @@ partial class EfCoreMapper
                         ? "Adult"
                         : "Senior",
             Summary = p.BirthInfo != null
-                ? p.Name + " (" + p.BirthInfo.Age + " years old) from " + (p.BirthInfo.BirthPlace ?? "Unknown") 
+                ? p.Name + " (" + p.BirthInfo.Age + " years old) from " + (p.BirthInfo.BirthPlace ?? "Unknown")
                 : p.Name + " (unknown age) from Unknown"
         };
 
@@ -82,7 +82,7 @@ partial class EfCoreMapper
     /// </remarks>
     public static Expression<Func<Person, int?>> GetPersonAgeExpression() => 
         person => (person.BirthInfo != null
-            ? (person.BirthInfo.Age) 
+            ? (person.BirthInfo.Age)
             : (int?)null);
 
     /// <summary>
@@ -95,7 +95,7 @@ partial class EfCoreMapper
     /// </remarks>
     public static Expression<Func<Person, bool>> IsOlderThan30Expression() => 
         person => (person.BirthInfo != null
-            ? (person.BirthInfo.Age) 
+            ? (person.BirthInfo.Age)
             : (int?)null) > 30;
 
     /// <summary>
@@ -108,7 +108,7 @@ partial class EfCoreMapper
     /// </remarks>
     public static Expression<Func<Person, string>> GetBirthPlaceExpression() => 
         person => (person.BirthInfo != null
-            ? (person.BirthInfo.BirthPlace) 
+            ? (person.BirthInfo.BirthPlace)
             : (string)null) ?? "Unknown";
 
     /// <summary>
@@ -121,7 +121,7 @@ partial class EfCoreMapper
     /// </remarks>
     public static Expression<Func<Person, string>> GetBirthAddressExpression() => 
         person => (person.BirthInfo != null
-            ? (person.BirthInfo.Address) 
+            ? (person.BirthInfo.Address)
             : (string)null) ?? "Not specified";
 
     /// <summary>
@@ -145,7 +145,7 @@ partial class EfCoreMapper
     /// </remarks>
     public static Expression<Func<Person, bool>> IsAdultExpression() => 
         person => (person.BirthInfo != null
-            ? (person.BirthInfo.Age) 
+            ? (person.BirthInfo.Age)
             : (int?)null) >= 18;
 
     /// <summary>
@@ -158,7 +158,7 @@ partial class EfCoreMapper
     /// </remarks>
     public static Expression<Func<Person, bool>> BornInUkraineExpression() => 
         person => (person.BirthInfo != null
-            ? (person.BirthInfo.Address) 
+            ? (person.BirthInfo.Address)
             : (string)null) != null && person.BirthInfo.Address.Contains("Ukraine");
 
     /// <summary>
@@ -215,7 +215,7 @@ partial class EfCoreMapper
     /// </remarks>
     public static Expression<Func<Person, string>> GetFirstActiveAddressCityExpression() => 
         person => (person.Addresses.FirstOrDefault(a => a.IsActive) != null
-            ? (person.Addresses.FirstOrDefault(a => a.IsActive).City) 
+            ? (person.Addresses.FirstOrDefault(a => a.IsActive).City)
             : (string)null) ?? "No active address";
 
     /// <summary>
@@ -245,7 +245,7 @@ partial class EfCoreMapper
             .FirstOrDefault() != null
             ? (person.Orders
                 .OrderByDescending(o => o.OrderDate)
-                .FirstOrDefault().OrderNumber) 
+                .FirstOrDefault().OrderNumber)
             : (string)null) ?? "No orders";
 
     /// <summary>
@@ -258,7 +258,7 @@ partial class EfCoreMapper
     /// </remarks>
     public static Expression<Func<Person, string>> GetPersonSummaryExpression() => 
         person => person.BirthInfo != null
-            ? person.Name + " (" + person.BirthInfo.Age + " years old) from " + (person.BirthInfo.BirthPlace ?? "Unknown") 
+            ? person.Name + " (" + person.BirthInfo.Age + " years old) from " + (person.BirthInfo.BirthPlace ?? "Unknown")
             : person.Name + " (unknown age) from Unknown";
 
     /// <summary>
@@ -271,8 +271,9 @@ partial class EfCoreMapper
     /// </remarks>
     public static Expression<Func<Person, bool>> LivesInSamePlaceAsBornExpression() => 
         person => (person.BirthInfo != null
-            ? (person.BirthInfo.BirthPlace) 
-            : (string)null) != null && person.Addresses.Any(a => a.IsActive && a.City == person.BirthInfo.BirthPlace);
+            ? (person.BirthInfo.BirthPlace)
+            : (string)null) != null
+            && person.Addresses.Any(a => a.IsActive && a.City == person.BirthInfo.BirthPlace);
 
     /// <summary>
     /// This is an auto-generated expression companion for <see cref="GetPersonCategory(Person)"/>.

--- a/tests/AlephMapper.Tests/Files/Expressive/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Expressive/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class SampleMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ConditionalExtensionTestPersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ConditionalExtensionTestPersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class ConditionalExtensionTestPersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestAddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestAddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class ExtensionTestAddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestPersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ExtensionMethodInlining/Expected/AlephMapper_Tests_ExtensionTestPersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class ExtensionTestPersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/Mapper/Expected/AlephMapper_Tests_Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Mapper/Expected/AlephMapper_Tests_Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/Mapper/Expected/AlephMapper_Tests_Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Mapper/Expected/AlephMapper_Tests_Mapper_GeneratedMappings.g.cs
@@ -114,7 +114,7 @@ partial class Mapper
         {
             Name = source.Name,
             BirthInfo = source.BirthInfo == null
-                ? null 
+                ? null
                 : new BirthInfoDto
                 {
                     Age = source.BirthInfo.Age,

--- a/tests/AlephMapper.Tests/Files/MethodGroupSpec/Expected/AlephMapper_Tests_SimpleObjectMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MethodGroupSpec/Expected/AlephMapper_Tests_SimpleObjectMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class SimpleObjectMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MethodGroupToEntityList/Expected/AlephMapper_Tests_MethodGroupToEntityList_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MethodGroupToEntityList/Expected/AlephMapper_Tests_MethodGroupToEntityList_PersonMapper_GeneratedMappings.g.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MethodGroupToEntityList;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperIgnore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperIgnore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class PersonProductMapperIgnore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperRewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperRewrite_GeneratedMappings.g.cs
@@ -22,7 +22,7 @@ partial class PersonProductMapperRewrite
         {
             Name = person.Name,
             FavoritePrice = (person.FavoriteProduct != null
-                ? ("$" + person.FavoriteProduct.Price) 
+                ? ("$" + person.FavoriteProduct.Price)
                 : (string)null)
         };
 }

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperRewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_PersonProductMapperRewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class PersonProductMapperRewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_ProductMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParamExtensionInlining/Expected/AlephMapper_Tests_MultiParamExtensionInlining_ProductMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParamExtensionInlining;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class ProductMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_MultiParamExpressiveMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_MultiParamExpressiveMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class MultiParamExpressiveMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NamedArgMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NamedArgMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class NamedArgMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NestedMultiParamMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_NestedMultiParamMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class NestedMultiParamMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_PersonMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_PersonMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class PersonMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_UpdatableMultiParamMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/MultiParameterInlining/Expected/AlephMapper_Tests_MultiParameterInlining_UpdatableMultiParamMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests.MultiParameterInlining;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class UpdatableMultiParamMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_AddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_AddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class NestedExt_AddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Ignore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Ignore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class NestedExt_PersonMapper_Ignore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Rewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Rewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class NestedExt_PersonMapper_Rewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Rewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NestedConditionalExtensionInlining/Expected/AlephMapper_Tests_NestedExt_PersonMapper_Rewrite_GeneratedMappings.g.cs
@@ -27,9 +27,9 @@ partial class NestedExt_PersonMapper_Rewrite
                         {
                             Street = p.Friend.HomeAddress.Street,
                             City = p.Friend.HomeAddress.City
-                        }) 
-                        : (NestedExt_AddressDto)null)) 
-                    : (NestedExt_AddressDto)null)) 
+                        })
+                        : (NestedExt_AddressDto)null))
+                    : (NestedExt_AddressDto)null))
                 : (NestedExt_AddressDto)null)
         };
 }

--- a/tests/AlephMapper.Tests/Files/NullCoalesceValueAssignment/Expected/AlephMapper_Tests_NullCoalesceValueAssignmentMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullCoalesceValueAssignment/Expected/AlephMapper_Tests_NullCoalesceValueAssignmentMapper_GeneratedMappings.g.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class NullCoalesceValueAssignmentMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_IgnoreMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_IgnoreMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class IgnoreMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_NoneMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_NoneMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class NoneMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_RewriteMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_RewriteMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class RewriteMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_RewriteMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullConditionalRewrite/Expected/AlephMapper_Tests_RewriteMapper_GeneratedMappings.g.cs
@@ -18,7 +18,7 @@ partial class RewriteMapper
     /// </remarks>
     public static Expression<Func<SourceDto, string>> GetAddressExpression() => 
         dto => (dto.BirthInfo != null
-            ? (dto.BirthInfo.Address) 
+            ? (dto.BirthInfo.Address)
             : (string)null) ?? "Unknown";
 
     /// <summary>
@@ -31,6 +31,6 @@ partial class RewriteMapper
     /// </remarks>
     public static Expression<Func<SourceDto, bool>> HasAddressExpression() => 
         source => (source.BirthInfo != null
-            ? (source.BirthInfo.Address) 
+            ? (source.BirthInfo.Address)
             : (string)null) != null;
 }

--- a/tests/AlephMapper.Tests/Files/NullableDisabled/Expected/Tests_NullableDisabledMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullableDisabled/Expected/Tests_NullableDisabledMapper_GeneratedMappings.g.cs
@@ -19,6 +19,6 @@ partial class NullableDisabledMapper
     /// </remarks>
     public static Expression<Func<Person, string>> GetNameExpression() => 
         person => (person != null
-            ? (person.Name) 
+            ? (person.Name)
             : (string)null);
 }

--- a/tests/AlephMapper.Tests/Files/NullableDisabled/Expected/Tests_NullableDisabledMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullableDisabled/Expected/Tests_NullableDisabledMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class NullableDisabledMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/NullableEnabled/Expected/Tests_NullableEnabledMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullableEnabled/Expected/Tests_NullableEnabledMapper_GeneratedMappings.g.cs
@@ -19,6 +19,6 @@ partial class NullableEnabledMapper
     /// </remarks>
     public static Expression<Func<Person, string?>> GetNameExpression() => 
         person => (person != null
-            ? (person.Name) 
+            ? (person.Name)
             : (string?)null);
 }

--- a/tests/AlephMapper.Tests/Files/NullableEnabled/Expected/Tests_NullableEnabledMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/NullableEnabled/Expected/Tests_NullableEnabledMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class NullableEnabledMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtAddressMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtAddressMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class TechDebtAddressMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperIgnore_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperIgnore_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class TechDebtPersonMapperIgnore
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperNone_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperNone_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class TechDebtPersonMapperNone
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperRewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperRewrite_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class TechDebtPersonMapperRewrite
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperRewrite_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TechDebtFix/Expected/AlephMapper_Tests_TechDebtPersonMapperRewrite_GeneratedMappings.g.cs
@@ -22,7 +22,7 @@ partial class TechDebtPersonMapperRewrite
         {
             Name = person.Name,
             AddressStr = (person.Address != null
-                ? (person.Address.FormattedAddress) 
+                ? (person.Address.FormattedAddress)
                 : (string)null) ?? "No Address"
         };
 }

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_Address1Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_Address1Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class Address1Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_Address1Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_Address1Mapper_GeneratedMappings.g.cs
@@ -20,14 +20,14 @@ partial class Address1Mapper
         sourceAddress => new Address1Dto
         {
             Line1 = sourceAddress.Line1 == null
-                ? null 
+                ? null
                 : new AddressLineDto
                 {
                     Street = sourceAddress.Line1.Street,
                     HouseNumber = sourceAddress.Line1.HouseNumber
                 },
             Line2 = sourceAddress.Line2 == null
-                ? null 
+                ? null
                 : new AddressLineDto
                 {
                     Street = sourceAddress.Line2.Street,

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_AddressLineMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_AddressLineMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class AddressLineMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_AddressLineMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_AddressLineMapper_GeneratedMappings.g.cs
@@ -18,7 +18,7 @@ partial class AddressLineMapper
     /// </remarks>
     public static Expression<Func<AddressLine, AddressLineDto>> MapToDtoExpression() => 
         sourceAddressLine1 => sourceAddressLine1 == null
-            ? null 
+            ? null
             : new AddressLineDto
             {
                 Street = sourceAddressLine1.Street,

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_TestModel1Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_TestModel1Mapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class TestModel1Mapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_TestModel1Mapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/TestModel1Mapper/Expected/AlephMapper_Tests_TestModel1Mapper_GeneratedMappings.g.cs
@@ -25,14 +25,14 @@ partial class TestModel1Mapper
                 ? new Address1Dto
                 {
                     Line1 = source.Address.Line1 == null
-                        ? null 
+                        ? null
                         : new AddressLineDto
                         {
                             Street = source.Address.Line1.Street,
                             HouseNumber = source.Address.Line1.HouseNumber
                         },
                     Line2 = source.Address.Line2 == null
-                        ? null 
+                        ? null
                         : new AddressLineDto
                         {
                             Street = source.Address.Line2.Street,

--- a/tests/AlephMapper.Tests/Files/Updatable/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/Updatable/Expected/Tests_SampleMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using System.Linq.Expressions;
 
 namespace Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class SampleMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexPropertyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexPropertyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class ComplexPropertyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ComplexValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class ComplexValueTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_EdgeCaseMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_EdgeCaseMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class EdgeCaseMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_MixedTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_MixedTypeMapper_GeneratedMappings.g.cs
@@ -6,7 +6,7 @@ using TUnit.Core;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class MixedTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_NullableValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_NullableValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class NullableValueTypeMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ReferenceTypeOnlyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ReferenceTypeOnlyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class ReferenceTypeOnlyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_SimpleValueToReferenceMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_SimpleValueToReferenceMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class SimpleValueToReferenceMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueToReferenceMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueToReferenceMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class ValueToReferenceMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class ValueTypeMapper
 {
 }

--- a/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeOnlyMapper_GeneratedMappings.g.cs
+++ b/tests/AlephMapper.Tests/Files/ValueTypesAndReferenceTypes/Expected/AlephMapper_Tests_ValueTypeOnlyMapper_GeneratedMappings.g.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 
 namespace AlephMapper.Tests;
 
-[GeneratedCode("AlephMapper", "0.5.9")]
+[GeneratedCode("AlephMapper", "0.6.0")]
 partial class ValueTypeOnlyMapper
 {
     /// <summary>

--- a/tests/AlephMapper.Tests/SourceGeneratorTests.cs
+++ b/tests/AlephMapper.Tests/SourceGeneratorTests.cs
@@ -516,6 +516,98 @@ public class SourceGeneratorTests
     }
 
     [Test]
+    public async Task AdaptedOutputFormatsAnonymousObjectsInsideFluentChains()
+    {
+        const string source = """
+            using AlephMapper;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            namespace Fixture;
+
+            public static partial class Mapper
+            {
+                [Adapt(typeof(Employee), typeof(EmployeeDto), Name = "MapEmployee", Generate = AdaptGeneration.Expression)]
+                public static PersonDto MapPerson(Person source, string preferredLanguage, string fallbackLanguage) => new()
+                {
+                    Description = MapDescription(source.Value, preferredLanguage, fallbackLanguage)
+                };
+
+                private static string MapDescription(Value value, string preferredLanguage, string fallbackLanguage) =>
+                    value.Descriptions
+                        .Select(description => new
+                        {
+                            Order = description.Language == preferredLanguage ? 1 : description.Language == fallbackLanguage ? 2 : 3,
+                            Description = description.Text
+                        })
+                        .Where(description => description.Order < 3)
+                        .OrderBy(description => description.Order)
+                        .Select(description => description.Description)
+                        .FirstOrDefault() ?? value.Code;
+            }
+
+            public sealed class Person { public Value Value { get; set; } = new(); }
+            public sealed class Employee { public Value Value { get; set; } = new(); }
+            public sealed class PersonDto { public string Description { get; set; } = string.Empty; }
+            public sealed class EmployeeDto { public string Description { get; set; } = string.Empty; }
+            public sealed class Value { public string Code { get; set; } = string.Empty; public List<Description> Descriptions { get; set; } = []; }
+            public sealed class Description { public string Language { get; set; } = string.Empty; public string Text { get; set; } = string.Empty; }
+            """;
+
+        var generatedSources = await AssertAdaptedOutputCompiles(source, "AnonymousObjectFluentChainAdapt");
+        var generatedSource = generatedSources.Single(sourceText => sourceText.Contains("MapEmployeeExpression"));
+
+        await Assert.That(generatedSource).DoesNotContain("new\r\n        {");
+        await Assert.That(generatedSource).DoesNotContain("new\n        {");
+        await Assert.That(generatedSource).Contains(".Select(description => new");
+        await Assert.That(generatedSource).Contains("Order = description.Language == preferredLanguage");
+    }
+
+    [Test]
+    public async Task ExpressionOutputFormatsLogicalConditionChains()
+    {
+        const string source = """
+            using AlephMapper;
+            using System;
+
+            namespace Fixture;
+
+            public static partial class Criteria
+            {
+                [Expressive]
+                public static bool HasCategoryLine(InvoiceLine line, Guid dataSetId, Guid invoiceId) =>
+                    line.Invoice.DataSetId == dataSetId &&
+                    line.Invoice.InvoiceIdReference == invoiceId &&
+                    line.CategoryId != null;
+
+                [Expressive]
+                public static bool HasCategoryLineSingleLine(InvoiceLine line, Guid dataSetId, Guid invoiceId) =>
+                    line.Invoice.DataSetId == dataSetId && line.Invoice.InvoiceIdReference == invoiceId && line.CategoryId != null;
+            }
+
+            public sealed class InvoiceLine
+            {
+                public Invoice Invoice { get; set; } = new();
+                public Guid? CategoryId { get; set; }
+            }
+
+            public sealed class Invoice
+            {
+                public Guid DataSetId { get; set; }
+                public Guid InvoiceIdReference { get; set; }
+            }
+            """;
+
+        var generatedSources = await AssertAdaptedOutputCompiles(source, "LogicalConditionChainExpression");
+        var generatedSource = generatedSources.Single(sourceText => sourceText.Contains("HasCategoryLineExpression"));
+
+        await Assert.That(generatedSource).Contains("line => line.Invoice.DataSetId == dataSetId");
+        await Assert.That(generatedSource).Contains($"{Environment.NewLine}            && line.Invoice.InvoiceIdReference == invoiceId");
+        await Assert.That(generatedSource).Contains($"{Environment.NewLine}            && line.CategoryId != null;");
+        await Assert.That(generatedSource).Contains("line => line.Invoice.DataSetId == dataSetId && line.Invoice.InvoiceIdReference == invoiceId && line.CategoryId != null;");
+    }
+
+    [Test]
     public async Task AdaptReportsIncompatibleDirectMemberAssignment()
     {
         const string source = """


### PR DESCRIPTION
## Summary

- Fix generated formatting for anonymous object initializers inside fluent LINQ chains, such as `.Select(x => new { ... })`.
- Format chained logical conditions (`&&` / `||`) across multiple lines only when the source expression already used multiline formatting.
- Preserve one-line generated logical predicates when the source predicate was one line.
- Trim trailing horizontal whitespace before emitted line breaks in generated code.
- Update source-generator baselines to reflect the cleaned formatting.
- Add regression coverage for adapted expressions that project anonymous objects inside fluent chains, multiline expressive predicates, and one-line expressive predicates.

## Validation

- `dotnet run --project D:\Play\AlephMapper\tests\AlephMapper.Tests\AlephMapper.Tests.csproj` (38 tests passed)
